### PR TITLE
Add collapse all button for files

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ In bigger projects with many files it also provides **context**, it gives you a 
 
 - Search within changed files
 
+- Collapse All
+
 ## Location
 
 By default, the tree view is located in its own container accessible from the activity bar on the left. However, it can be freely moved to any other location like Source Control or Explorer by dragging and dropping.

--- a/package.json
+++ b/package.json
@@ -153,6 +153,12 @@
                 "title": "Search Changes",
                 "icon": "$(search)",
                 "category": "Git Tree Compare"
+            },
+            {
+                "command": "gitTreeCompare.collapseAll",
+                "title": "Collapse All",
+                "icon": "$(collapse-all)",
+                "category": "Git Tree Compare"
             }
         ],
         "menus": {
@@ -231,6 +237,11 @@
                     "command": "gitTreeCompare.searchChanges",
                     "when": "view == gitTreeCompare",
                     "group": "2_files"
+                },
+                {
+                    "command": "gitTreeCompare.collapseAll",
+                    "when": "view == gitTreeCompare",
+                    "group": "navigation@4"
                 }
             ],
             "view/item/context": [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -93,6 +93,12 @@ export function activate(context: ExtensionContext) {
         runAfterInit(() => provider!.searchChanges());
     });
 
+    commands.registerCommand(NAMESPACE + '.collapseAll', () => {
+        runAfterInit(() => {
+            provider!.collapseAll();
+        });
+    });
+
     createGit(gitApi, outputChannel).then(async git => {
         const onOutput = (str: string) => outputChannel.append(str);
         git.onOutput.addListener('log', onOutput);

--- a/src/treeProvider.ts
+++ b/src/treeProvider.ts
@@ -141,6 +141,7 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
     constructor(private readonly git: Git, private readonly gitApi: GitAPI, private readonly outputChannel: OutputChannel, private readonly globalState: Memento,
                 private readonly asAbsolutePath: (relPath: string) => string) {
         this.readConfig();
+        this.collapseAll = this.collapseAll.bind(this);
     }
 
     async init(treeView: TreeView<Element>) {
@@ -1111,6 +1112,16 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
             filesToInclude: relativePaths.join(','),
             triggerSearch: true
         });
+    }
+
+    async collapseAll() {
+        const root = this.treeRoot;
+        const elements = this.getFileSystemEntries(root, false);
+        for (const element of elements) {
+            if (element instanceof FolderElement) {
+                this.treeView.reveal(element, { expand: false });
+            }
+        }
     }
 
     dispose(): void {


### PR DESCRIPTION
Related to #106

Add a 'Collapse All' button for files in the Git Tree Compare extension.

* **package.json**
  - Add a new command `gitTreeCompare.collapseAll` to the `commands` section.
  - Add the new command to the `view/title` menu section.

* **src/extension.ts**
  - Register the new command `gitTreeCompare.collapseAll`.
  - Implement the `collapseAll` command to collapse all tree items.

* **README.md**
  - Update the `README.md` to include the new 'Collapse All' feature.

* **src/treeProvider.ts**
  - Add a new method `collapseAll` to collapse all tree items.
  - Update the constructor to bind the new `collapseAll` method to the class.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/letmaik/vscode-git-tree-compare/pull/107?shareId=c6ec23b4-334d-4d54-8586-5b918ed7b67a).