### PR TITLE
Auto deploy on Open VSX and VS Marketplace

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,27 +1,31 @@
-name: CI
-
+name: Deploy Extension
 on:
   push:
-  pull_request:
-  workflow_dispatch:
+    tags:
+      - "*"
 
 jobs:
-  build:
-
+  deploy:
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v4
-    
-    - uses: actions/setup-node@v4
-      with:
-        node-version: 18.x
-    
-    - run: npm install
-    
-    - run: npx vsce package
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 24
+      - run: npm ci
 
-    - uses: actions/upload-artifact@v4
-      with:
-        name: package
-        path: '*.vsix'
+      - name: Publish to Open VSX Registry
+        uses: HaaLeo/publish-vscode-extension@v2
+        with:
+          pat: ${{ secrets.OPEN_VSX_TOKEN }}
+
+      - name: Publish to Visual Studio Marketplace
+        uses: HaaLeo/publish-vscode-extension@v2
+        with:
+          pat: ${{ secrets.VS_MARKETPLACE_TOKEN }}
+          registryUrl: https://marketplace.visualstudio.com
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: package
+          path: ${{ steps.publishToOpenVSX.outputs.vsixPath }}


### PR DESCRIPTION
Snippet taken from https://github.com/HaaLeo/publish-vscode-extension?tab=readme-ov-file#example

With these changes, new versions are deployed whenever you create a new git tag.

Other steps are still needed along with merging this PR, I sadly don't know them all but these should help:

* https://github.com/HaaLeo/publish-vscode-extension?tab=readme-ov-file#open-vsx-registry
* https://github.com/HaaLeo/publish-vscode-extension?tab=readme-ov-file#visual-studio-marketplace (or scroll down from previous link)
* https://github.com/eclipse/openvsx/wiki/Publishing-Extensions
* https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/use-secrets

If I can help out with any of these let me know and I'll see what I can do.

Closes #108 