### PR TITLE
Add configurable rename detection threshold

### DIFF
--- a/package.json
+++ b/package.json
@@ -361,6 +361,13 @@
                     "description": "Whether to detect renames. Does not affect untracked files. May have a performance impact.",
                     "default": true
                 },
+                "gitTreeCompare.renameThreshold": {
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 100,
+                    "description": "The similarity index (in percent) for rename detection. A value of 100 means that only identical files are detected as renames, a value of 0 means that any file with any similarity is detected as a rename. Has no effect if gitTreeCompare.findRenames is false.",
+                    "default": 50
+                },
                 "gitTreeCompare.openChanges": {
                     "type": "boolean",
                     "description": "When selecting a modified file in the tree, whether to show its changes or just open the workspace file.",

--- a/src/gitHelper.ts
+++ b/src/gitHelper.ts
@@ -207,7 +207,7 @@ function parseDiffIndexOutput(repoRoot: string, out: string): IDiffStatus[] {
     return entries;
 }
 
-export async function diffIndex(repo: Repository, ref: string, refreshIndex: boolean, findRenames: boolean): Promise<IDiffStatus[]> {
+export async function diffIndex(repo: Repository, ref: string, refreshIndex: boolean, findRenames: boolean, renameThreshold: number): Promise<IDiffStatus[]> {
     if (refreshIndex) {
         // avoid superfluous diff entries if files only got touched
         // (see https://github.com/letmaik/vscode-git-tree-compare/issues/37)
@@ -219,8 +219,7 @@ export async function diffIndex(repo: Repository, ref: string, refreshIndex: boo
     }
 
     // exceptions can happen with newly initialized repos without commits, or when git is busy
-    
-    const renamesFlag = findRenames ? '--find-renames' : '--no-renames';
+    const renamesFlag = findRenames ? `--find-renames=${renameThreshold}%`  : '--no-renames';
     let diffIndexResult = await repo.exec(['diff-index', '-z', renamesFlag, ref, '--']);
     let untrackedResult = await repo.exec(['ls-files', '-z', '--others', '--exclude-standard']);
 

--- a/src/treeProvider.ts
+++ b/src/treeProvider.ts
@@ -100,6 +100,7 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
     private iconsMinimal: boolean;
     private fullDiff: boolean;
     private findRenames: boolean;
+    private renameThreshold: number;
     private showCollapsed: boolean;
     private compactFolders: boolean;
     private showCheckboxes: boolean;
@@ -342,6 +343,7 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
         this.iconsMinimal = config.get<boolean>('iconsMinimal', false);
         this.fullDiff = config.get<string>('diffMode') === 'full';
         this.findRenames = config.get<boolean>('findRenames', true);
+        this.renameThreshold = config.get<number>('renameThreshold', 50);
         this.showCollapsed = config.get<boolean>('collapsed', false);
         this.compactFolders = config.get<boolean>('compactFolders', false);
         this.showCheckboxes = config.get<boolean>('showCheckboxes', false);
@@ -507,7 +509,7 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
         const filesInsideTreeRoot = new Map<FolderAbsPath, IDiffStatus[]>();
         const filesOutsideTreeRoot = new Map<FolderAbsPath, IDiffStatus[]>();
 
-        const diff = await diffIndex(this.repository!, this.mergeBase, this.refreshIndex, this.findRenames);
+        const diff = await diffIndex(this.repository!, this.mergeBase, this.refreshIndex, this.findRenames, this.renameThreshold);
         const untrackedCount = diff.reduce((prev, cur, _) => prev + (cur.status === 'U' ? 1 : 0), 0);
         this.log(`${diff.length} diff entries (${untrackedCount} untracked)`);
 
@@ -662,6 +664,7 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
         const oldIconsMinimal = this.iconsMinimal;
         const oldFullDiff = this.fullDiff;
         const oldFindRenames = this.findRenames;
+        const oldRenameThreshold = this.renameThreshold;
         const oldCompactFolders = this.compactFolders;
         const oldshowCheckboxes = this.showCheckboxes;
         this.readConfig();
@@ -673,6 +676,7 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
             (!oldRefreshIndex && this.refreshIndex) ||
             oldFullDiff != this.fullDiff ||
             oldFindRenames != this.findRenames ||
+            oldRenameThreshold != this.renameThreshold ||
             oldCompactFolders != this.compactFolders ||
             oldshowCheckboxes != this.showCheckboxes) {
 
@@ -687,6 +691,7 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
             
             if (oldFullDiff != this.fullDiff || 
                 oldFindRenames != this.findRenames ||
+                oldRenameThreshold != this.renameThreshold ||
                 oldTreeRoot != this.treeRoot ||
                 (!oldAutoRefresh && this.autoRefresh) ||
                 (!oldRefreshIndex && this.refreshIndex)) {


### PR DESCRIPTION
Added renameThreshold setting to control git diff rename similarity index.

see [https://git-scm.com/docs/git-diff#Documentation/git-diff.txt---find-renamesn](https://git-scm.com/docs/git-diff#Documentation/git-diff.txt---find-renamesn)