### PR TITLE
Enable display and monitor of diff hunks inside files

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,12 +138,12 @@
             },
             {
                 "command": "gitTreeCompare.showDiffDetails",
-                "title": "Show diff details",
+                "title": "Show hunks",
                 "category": "Git Tree Compare"
             },
             {
                 "command": "gitTreeCompare.hideDiffDetails",
-                "title": "Hide diff details",
+                "title": "Hide hunks",
                 "category": "Git Tree Compare"
             },
             {
@@ -296,32 +296,32 @@
                 {
                     "command": "gitTreeCompare.switchToFullDiff",
                     "when": "view == gitTreeCompare && config.gitTreeCompare.diffMode == merge",
-                    "group": "3_options"
+                    "group": "3_options@3"
                 },
                 {
                     "command": "gitTreeCompare.switchToMergeDiff",
                     "when": "view == gitTreeCompare && config.gitTreeCompare.diffMode == full",
-                    "group": "3_options"
+                    "group": "3_options@3"
                 },
                 {
                     "command": "gitTreeCompare.showCheckboxes",
                     "when": "view == gitTreeCompare && !config.gitTreeCompare.showCheckboxes",
-                    "group": "3_options"
+                    "group": "3_options@1"
                 },
                 {
                     "command": "gitTreeCompare.hideCheckboxes",
                     "when": "view == gitTreeCompare && config.gitTreeCompare.showCheckboxes",
-                    "group": "3_options"
+                    "group": "3_options@1"
                 },
                 {
                     "command": "gitTreeCompare.showDiffDetails",
                     "when": "view == gitTreeCompare && !config.gitTreeCompare.showDiffDetails",
-                    "group": "3_options"
+                    "group": "3_options@2"
                 },
                 {
                     "command": "gitTreeCompare.hideDiffDetails",
                     "when": "view == gitTreeCompare && config.gitTreeCompare.showDiffDetails",
-                    "group": "3_options"
+                    "group": "3_options@2"
                 },
                 {
                     "command": "gitTreeCompare.viewAsList",

--- a/package.json
+++ b/package.json
@@ -137,6 +137,16 @@
                 "category": "Git Tree Compare"
             },
             {
+                "command": "gitTreeCompare.showDiffDetails",
+                "title": "Show diff details",
+                "category": "Git Tree Compare"
+            },
+            {
+                "command": "gitTreeCompare.hideDiffDetails",
+                "title": "Hide diff details",
+                "category": "Git Tree Compare"
+            },
+            {
                 "command": "gitTreeCompare.viewAsList",
                 "title": "View as List",
                 "icon": "$(list-flat)",
@@ -301,6 +311,16 @@
                 {
                     "command": "gitTreeCompare.hideCheckboxes",
                     "when": "view == gitTreeCompare && config.gitTreeCompare.showCheckboxes",
+                    "group": "3_options"
+                },
+                {
+                    "command": "gitTreeCompare.showDiffDetails",
+                    "when": "view == gitTreeCompare && !config.gitTreeCompare.showDiffDetails",
+                    "group": "3_options"
+                },
+                {
+                    "command": "gitTreeCompare.hideDiffDetails",
+                    "when": "view == gitTreeCompare && config.gitTreeCompare.showDiffDetails",
                     "group": "3_options"
                 },
                 {
@@ -530,6 +550,11 @@
                     "type": "boolean",
                     "description": "Whether to show checkboxes such that files or folders can be ticked off, for example when reviewing.",
                     "default": false
+                },
+                "gitTreeCompare.showDiffDetails": {
+                    "type": "boolean",
+                    "description": "Whether to show diff details (hunks) for each file. When enabled, files can be expanded to view individual changes.",
+                    "default": true
                 },
                 "gitTreeCompare.resetCheckboxOnFileChange": {
                     "type": "boolean",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -32,6 +32,12 @@ export function activate(context: ExtensionContext) {
         });
     });
 
+    commands.registerCommand(NAMESPACE + '.openChangesAtLine', node => {
+        runAfterInit(() => {
+            provider!.openChangesAtLine(node);
+        });
+    });
+
     commands.registerCommand(NAMESPACE + '.openFile', (node, nodes) => {
         runAfterInit(() => {
             provider!.openFile(nodes || [node]);
@@ -128,7 +134,8 @@ export function activate(context: ExtensionContext) {
         // Set initial context for menu enablement (starts in tree view mode)
         commands.executeCommand('setContext', NAMESPACE + '.viewAsList', false);
 
-        provider = new GitTreeCompareProvider(git, gitApi, outputChannel, context.globalState, context.asAbsolutePath);
+        const storageUri = context.storageUri || context.globalStorageUri;
+        provider = new GitTreeCompareProvider(git, gitApi, outputChannel, context.globalState, context.asAbsolutePath, storageUri);
 
         const treeView = window.createTreeView(
             NAMESPACE,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -94,6 +94,12 @@ export function activate(context: ExtensionContext) {
     commands.registerCommand(NAMESPACE + '.hideCheckboxes', () => {
         runAfterInit(() => provider!.hideCheckboxes(true));
     });
+    commands.registerCommand(NAMESPACE + '.showDiffDetails', () => {
+        runAfterInit(() => provider!.hideDiffDetails(false));
+    });
+    commands.registerCommand(NAMESPACE + '.hideDiffDetails', () => {
+        runAfterInit(() => provider!.hideDiffDetails(true));
+    });
     commands.registerCommand(NAMESPACE + '.viewAsList', () => {
         runAfterInit(() => provider!.viewAsTree(false));
     });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -32,12 +32,6 @@ export function activate(context: ExtensionContext) {
         });
     });
 
-    commands.registerCommand(NAMESPACE + '.openChangesAtLine', node => {
-        runAfterInit(() => {
-            provider!.openChangesAtLine(node);
-        });
-    });
-
     commands.registerCommand(NAMESPACE + '.openFile', (node, nodes) => {
         runAfterInit(() => {
             provider!.openFile(nodes || [node]);

--- a/src/treeProvider.ts
+++ b/src/treeProvider.ts
@@ -1,6 +1,7 @@
 import * as assert from 'assert'
 import * as path from 'path'
 import * as fs from 'fs'
+import * as crypto from 'crypto'
 
 import { TreeDataProvider, TreeItem, TreeItemCollapsibleState,
          Uri, Disposable, EventEmitter, TextDocumentShowOptions,
@@ -47,22 +48,17 @@ class FileElement implements IDiffStatus {
 }
 
 class DiffHunkElement {
+    static readonly HUNK_CONTEXT_LINES = 5;
     constructor(
         public fileElement: FileElement,
-        public oldStart: number,
-        public oldLines: number,
         public newStart: number,
-        public newLines: number,
-        public header: string,
         public preview: string,
-        public firstLine: string,
-        public lines: string[] = []) {}
+        public hash: string,
+        public status: 'A' | 'M' | 'D') {}
 
     get label(): string {
-        return `@@ -${this.oldStart},${this.oldLines} +${this.newStart},${this.newLines} @@`;
+        return this.preview || `Line ${this.newStart}`;
     }
-
-    
 }
 
 class FolderElement {
@@ -165,6 +161,7 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
     // Diff results
     private filesInsideTreeRoot: Map<FolderAbsPath, IDiffStatus[]>;
     private filesOutsideTreeRoot: Map<FolderAbsPath, IDiffStatus[]>;
+    private hunksMap: Map<string, DiffHunkElement[]>;
 
     // UI parameters, derived
     private treeRoot: FolderAbsPath;
@@ -345,10 +342,10 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
         const diff: DiffHunkElement[][] = [[],[]];
         for (const [element, state] of e.items) {
             if (element instanceof FileElement) {
-                const childHunkPresent = e.items.some(([nextElement, _]) => nextElement instanceof DiffHunkElement && nextElement.fileElement === element);
+                const childHunkPresent = e.items.some(([nextElement, _]) => nextElement instanceof DiffHunkElement && nextElement.fileElement.dstAbsPath === element.dstAbsPath);
                 if (!childHunkPresent) {
                     // process only if hunk of these files are not already included in event
-                    const hunks = await this.getDiffHunks(element);
+                    const hunks = await this.getDiffHunks(element.dstAbsPath);
                     diff[state].push(...hunks);
                 }
             } else if (element instanceof FolderElement) {
@@ -358,9 +355,7 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
                     for (const [folderPath, fileEntries] of files.entries()) {
                         if (folderPath === element.dstAbsPath || folderPath.startsWith(element.dstAbsPath + path.sep)) {
                             for (const file of fileEntries) {
-                                const fileElement = new FileElement(file.srcAbsPath, file.dstAbsPath, 
-                                    path.relative(this.treeRoot, file.dstAbsPath), file.status, file.isSubmodule);
-                                const hunks = await this.getDiffHunks(fileElement);
+                                const hunks = await this.getDiffHunks(file.dstAbsPath);
                                 diff[state].push(...hunks);
                             }
                         }
@@ -381,36 +376,19 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
         }
         try {
             const repoName = path.basename(this.repository.root);
-            const storagePath = path.join(this.storageUri.fsPath, `checked-hunks-${repoName}-${this.mergeBase}.diff`);
+            const storagePath = path.join(this.storageUri.fsPath, `checked-hunks-${repoName}-${this.mergeBase}.json`);
             
             if (!fs.existsSync(storagePath)) {
                 return false;
             }
             
             const content = fs.readFileSync(storagePath, 'utf-8');
-            const lines = content.split('\n');
+            const data = JSON.parse(content);
             
-            let currentFile = '';
             const targetFile = element.fileElement.dstAbsPath;
-            const targetLine = element.newStart;
+            const targetHash = element.hash;
             
-            for (const line of lines) {
-                if (line.startsWith('diff --git')) {
-                    const match = line.match(/b\/(.+)$/);
-                    if (match) {
-                        currentFile = match[1];
-                    }
-                } else if (line.startsWith('@@') && currentFile === targetFile) {
-                    const match = line.match(/^@@ -\d+,\d+ \+(\d+),\d+/);
-                    if (match) {
-                        const lineNum = parseInt(match[1]);
-                        if (lineNum === targetLine) {
-                            return true;
-                        }
-                    }
-                }
-            }
-            return false;
+            return data[targetFile] && data[targetFile].includes(targetHash);
         } catch (error) {
             return false;
         }
@@ -422,119 +400,41 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
         }
         try {
             const repoName = path.basename(this.repository.root);
-            const storagePath = path.join(this.storageUri.fsPath, `checked-hunks-${repoName}-${this.mergeBase}.diff`);
+            const storagePath = path.join(this.storageUri.fsPath, `checked-hunks-${repoName}-${this.mergeBase}.json`);
             
-            // Structure pour stocker les hunks par fichier avec leur contenu complet
-            const fileHunks = new Map<string, Array<{oldStart: number, oldLines: number, newStart: number, newLines: number, header: string, lines: string[]}>>();
-            
-            // Lire le fichier existant et parser le format complet
+            // Lire le fichier existant
+            let data: { [filepath: string]: string[] } = {};
             if (fs.existsSync(storagePath)) {
                 const content = await fs.promises.readFile(storagePath, 'utf-8');
-                const lines = content.split('\n');
-                let currentFile = '';
-                let currentHunk: {oldStart: number, oldLines: number, newStart: number, newLines: number, header: string, lines: string[]} | null = null;
-                const hunkHeaderRegex = /^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@(.*)$/;
-                
-                for (const line of lines) {
-                    if (line.startsWith('diff --git')) {
-                        if (currentHunk && currentFile) {
-                            if (!fileHunks.has(currentFile)) {
-                                fileHunks.set(currentFile, []);
-                            }
-                            fileHunks.get(currentFile)!.push(currentHunk);
-                        }
-                        const match = line.match(/b\/(.+)$/);
-                        if (match) {
-                            currentFile = match[1];
-                            currentHunk = null;
-                        }
-                    } else if (line.startsWith('---') || line.startsWith('+++')) {
-                        // Ignorer les headers de fichier
-                        continue;
-                    } else if (line.startsWith('@@')) {
-                        if (currentHunk && currentFile) {
-                            if (!fileHunks.has(currentFile)) {
-                                fileHunks.set(currentFile, []);
-                            }
-                            fileHunks.get(currentFile)!.push(currentHunk);
-                        }
-                        const match = hunkHeaderRegex.exec(line);
-                        if (match) {
-                            const oldStart = parseInt(match[1]);
-                            const oldLines = match[2] ? parseInt(match[2]) : 1;
-                            const newStart = parseInt(match[3]);
-                            const newLines = match[4] ? parseInt(match[4]) : 1;
-                            const header = match[5];
-                            currentHunk = {oldStart, oldLines, newStart, newLines, header, lines: []};
-                        }
-                    } else if (currentHunk && (line.startsWith('+') || line.startsWith('-') || line.startsWith(' '))) {
-                        currentHunk.lines.push(line);
-                    }
-                }
-                
-                // Ajouter le dernier hunk
-                if (currentHunk && currentFile) {
-                    if (!fileHunks.has(currentFile)) {
-                        fileHunks.set(currentFile, []);
-                    }
-                    fileHunks.get(currentFile)!.push(currentHunk);
-                }
+                data = JSON.parse(content);
             }
             
-            // Traiter chaque élément du tableau
+            // Mettre à jour les hunks
             for (const element of elements) {
                 const filepath = element.fileElement.dstAbsPath;
-                const targetNewStart = element.newStart;
+                const hash = element.hash;
                 
-                if (!fileHunks.has(filepath)) {
-                    fileHunks.set(filepath, []);
+                if (!data[filepath]) {
+                    data[filepath] = [];
                 }
-                
-                const hunks = fileHunks.get(filepath)!;
-                const existingIndex = hunks.findIndex(h => h.newStart === targetNewStart);
                 
                 if (added) {
-                    // Ajouter le hunk s'il n'existe pas déjà
-                    if (existingIndex < 0) {
-                        hunks.push({
-                            oldStart: element.oldStart,
-                            oldLines: element.oldLines,
-                            newStart: element.newStart,
-                            newLines: element.newLines,
-                            header: element.header,
-                            lines: element.lines
-                        });
-                        // Trier les hunks par position
-                        hunks.sort((a, b) => a.newStart - b.newStart);
+                    // Ajouter le hash s'il n'existe pas déjà
+                    if (!data[filepath].includes(hash)) {
+                        data[filepath].push(hash);
                     }
                 } else {
-                    // Retirer le hunk
-                    if (existingIndex >= 0) {
-                        hunks.splice(existingIndex, 1);
-                        if (hunks.length === 0) {
-                            fileHunks.delete(filepath);
-                        }
-                    }
-                }
-            }
-            
-            // Générer le fichier diff au format git diff complet
-            const diffLines: string[] = [];
-            for (const [filepath, hunks] of fileHunks) {
-                if (hunks.length > 0) {
-                    diffLines.push(`diff --git a/${filepath} b/${filepath}`);
-                    diffLines.push(`--- a/${filepath}`);
-                    diffLines.push(`+++ b/${filepath}`);
-                    
-                    for (const hunk of hunks) {
-                        diffLines.push(`@@ -${hunk.oldStart},${hunk.oldLines} +${hunk.newStart},${hunk.newLines} @@${hunk.header}`);
-                        diffLines.push(...hunk.lines);
+                    // Retirer le hash
+                    data[filepath] = data[filepath].filter(h => h !== hash);
+                    if (data[filepath].length === 0) {
+                        delete data[filepath];
                     }
                 }
             }
             
             await fs.promises.mkdir(path.dirname(storagePath), { recursive: true });
-            await fs.promises.writeFile(storagePath, diffLines.join('\n'), 'utf-8');
+            await fs.promises.writeFile(storagePath, JSON.stringify(data, null, 2), 'utf-8');
+            this.log(`Saved ${added ? 'added' : 'removed'} ${elements.length} hunks to ${storagePath}`);
         } catch (error) {
             this.log('Failed to save checked hunks', error as Error);
         }
@@ -615,7 +515,7 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
         if (this.showCheckboxes) {
             if (element instanceof FileElement) {
                 // Compute file state from hunks: checked if all hunks are checked
-                checkboxState = await this.computeFileCheckboxState(element);
+                checkboxState = await this.computeFileCheckboxState(element.dstAbsPath);
             } else if (element instanceof FolderElement) {
                 // Compute folder state from children: checked if all children are checked
                 checkboxState = await this.computeFolderCheckboxState(element);
@@ -626,9 +526,9 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
         return toTreeItem(element, this.openChangesOnSelect, this.iconsMinimal, this.showCollapsed, this.viewAsList, checkboxState, this.showDiffDetails, this.asAbsolutePath);
     }
 
-    private async computeFileCheckboxState(file: FileElement): Promise<TreeItemCheckboxState> {
+    private async computeFileCheckboxState(dstAbsPath: string): Promise<TreeItemCheckboxState> {
         let hasHunks = false;
-        const hunks = await this.getDiffHunks(file);
+        const hunks = await this.getDiffHunks(dstAbsPath);
         for (const hunkElement of hunks) {
             if (!this.isHunkChecked(hunkElement)) {
                 return TreeItemCheckboxState.Unchecked;
@@ -648,8 +548,7 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
             if (folderPath === folder.dstAbsPath || folderPath.startsWith(folder.dstAbsPath + path.sep)) {
                 for (const file of fileEntries) {
                     hasFiles = true;
-                    const fileState = await this.computeFileCheckboxState(new FileElement(file.srcAbsPath, file.dstAbsPath, 
-                        path.relative(this.treeRoot, file.dstAbsPath), file.status, file.isSubmodule));
+                    const fileState = await this.computeFileCheckboxState(file.dstAbsPath);
                     if (fileState !== TreeItemCheckboxState.Checked) {
                         return TreeItemCheckboxState.Unchecked;
                     }
@@ -689,122 +588,15 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
             return this.getFileSystemEntries(element.dstAbsPath, element.useFilesOutsideTreeRoot);
         } else if (element instanceof FileElement) {
             // Return diff hunks for this file
-            return await this.getDiffHunks(element);
+            return await this.getDiffHunks(element.dstAbsPath);
         }
         assert(false, "unsupported element type");
         return [];
     }
 
-    private async getDiffHunks(fileElement: FileElement): Promise<DiffHunkElement[]> {
-        if (fileElement.status === 'U' || fileElement.status === 'A' || fileElement.status === 'D') {
-            // Pour les fichiers non trackés, ajoutés ou supprimés, pas de hunks détaillés
-            return [];
-        }
-
-        try {
-            const dstRelPath = path.relative(this.repository!.root, fileElement.dstAbsPath);
-            // Utiliser git diff avec -U1 (1 ligne de contexte) et -w (ignorer whitespaces)
-            const result = await this.repository!.exec(['diff', '-U0', '-w', this.mergeBase, '--', dstRelPath]);
-            
-            const parsedHunks = this.parseDiffHunks(fileElement, result.stdout);
-            this.log(`Parsed ${parsedHunks.length} hunks for ${fileElement.dstAbsPath}`);
-            return parsedHunks;
-        } catch (e) {
-            this.log('Error getting diff hunks', e as Error);
-            return [];
-        }
-    }
-
-    private parseDiffHunks(fileElement: FileElement, diffOutput: string): DiffHunkElement[] {
-        const hunks: DiffHunkElement[] = [];
-        const lines = diffOutput.split('\n');
-        
-        // Regex pour extraire les informations du header de hunk: @@ -oldStart,oldLines +newStart,newLines @@
-        const hunkHeaderRegex = /^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@(.*)$/;
-        
-        let currentHunk: { oldStart: number; oldLines: number; newStart: number; newLines: number; header: string; lines: string[] } | null = null;
-        let hunkCount = 0;
-        
-        for (let i = 0; i < lines.length; i++) {
-            const line = lines[i];
-            const match = hunkHeaderRegex.exec(line);
-            
-            if (match) {
-                hunkCount++;
-                this.log(`Found hunk header #${hunkCount}: ${line}`);
-                
-                // Sauvegarder le hunk précédent s'il existe
-                if (currentHunk) {
-                    const preview = currentHunk.lines.slice(0, 3).join('\n');
-                    // Trouver la première ligne avec + ou -
-                    const firstAddedLine = currentHunk.lines.find(l => l.startsWith('+') && !l.startsWith('+++'));
-                    const firstRemovedLine = currentHunk.lines.find(l => l.startsWith('-') && !l.startsWith('---'));
-                    let firstLine = '';
-                    if (firstAddedLine) {
-                        firstLine = firstAddedLine.substring(1).trim();
-                    } else if (firstRemovedLine) {
-                        firstLine = ' - ' + firstRemovedLine.substring(1).trim();
-                    }
-                    hunks.push(new DiffHunkElement(
-                        fileElement,
-                        currentHunk.oldStart,
-                        currentHunk.oldLines,
-                        currentHunk.newStart,
-                        currentHunk.newLines,
-                        currentHunk.header,
-                        preview,
-                        firstLine,
-                        currentHunk.lines
-                    ));
-                }
-                
-                // Commencer un nouveau hunk
-                const oldStart = parseInt(match[1]);
-                const oldLines = match[2] ? parseInt(match[2]) : 1;
-                const newStart = parseInt(match[3]);
-                const newLines = match[4] ? parseInt(match[4]) : 1;
-                const header = match[5].trim();
-                
-                currentHunk = {
-                    oldStart,
-                    oldLines,
-                    newStart,
-                    newLines,
-                    header,
-                    lines: []
-                };
-            } else if (currentHunk && (line.startsWith('+') || line.startsWith('-') || line.startsWith(' '))) {
-                // Collecter les lignes du hunk
-                currentHunk.lines.push(line);
-            }
-        }
-        
-        // Ajouter le dernier hunk
-        if (currentHunk) {
-            const preview = currentHunk.lines.slice(0, 3).join('\n');
-            // Trouver la première ligne avec + ou -
-            const firstAddedLine = currentHunk.lines.find(l => l.startsWith('+') && !l.startsWith('+++'));
-            const firstRemovedLine = currentHunk.lines.find(l => l.startsWith('-') && !l.startsWith('---'));
-            let firstLine = '';
-            if (firstAddedLine) {
-                firstLine = firstAddedLine.substring(1).trim();
-            } else if (firstRemovedLine) {
-                firstLine = ' - ' + firstRemovedLine.substring(1).trim();
-            }
-            hunks.push(new DiffHunkElement(
-                fileElement,
-                currentHunk.oldStart,
-                currentHunk.oldLines,
-                currentHunk.newStart,
-                currentHunk.newLines,
-                currentHunk.header,
-                preview,
-                firstLine,
-                currentHunk.lines
-            ));
-        }
-        
-        return hunks;
+    private async getDiffHunks(dstAbsPath: string): Promise<DiffHunkElement[]> {
+        const hunks = this.hunksMap.get(dstAbsPath);
+        return hunks || [];
     }
 
     private async updateRefs(baseRef?: string): Promise<void>
@@ -971,10 +763,152 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
         this.filesInsideTreeRoot = filesInsideTreeRoot;
         this.filesOutsideTreeRoot = filesOutsideTreeRoot;
 
+        // Récupérer les hunks pour tous les fichiers en un seul appel git diff
+        const hunksMap = new Map<string, DiffHunkElement[]>();
+        try {
+            const result = await this.repository!.exec(['diff', `-U${DiffHunkElement.HUNK_CONTEXT_LINES}`, '-w', this.mergeBase]);
+
+            let gitDiff = result.stdout;
+
+            type HunkContext = {line:number, end:number, hash:crypto.Hash, preview:string, status:number};
+            do {
+                let currentHunk: HunkContext | null = null;
+                let closingHunk: HunkContext[] = [];
+                let currentFile: FileElement | null = null;
+                let fileSection = gitDiff.indexOf('+++ b/');
+                gitDiff = gitDiff.substring(fileSection + 6);
+                let fileEnd = gitDiff.indexOf('\n');
+                let filename = gitDiff.substring(0, fileEnd);
+                const entry = diff.find(e => e.dstAbsPath.endsWith(filename));
+                if(!entry) {
+                    continue;
+                }
+                currentFile = new FileElement(
+                    entry.srcAbsPath,
+                    entry.dstAbsPath,
+                    path.relative(this.treeRoot, entry.dstAbsPath),
+                    entry.status,
+                    entry.isSubmodule
+                )
+                if (!hunksMap.has(currentFile.dstAbsPath)) {
+                    hunksMap.set(currentFile.dstAbsPath, []);
+                }
+                let match = gitDiff.match(/@@ -\d+,\d+ \+(\d+),\d+ @@/);
+                let ctxLines: [number, number][] = [];
+                let ctxLinesIdx = 0;
+                let line = parseInt(match![1]) - 1;
+                let startOfLine = gitDiff.indexOf('\n', match!.index) + 1;
+                let inHunk = true;
+                while(inHunk) {
+                    const endOfLine = gitDiff.indexOf('\n', startOfLine) + 1;
+                    let mostRecent = false;
+                    switch (gitDiff[startOfLine]) {
+                        case ' ':
+                            if(currentHunk) {
+                                currentHunk.end = line;
+                                closingHunk.push(currentHunk);
+                                currentHunk = null;
+                            }
+                            mostRecent = true;
+                            break;
+                        case '+':
+                            mostRecent = true;
+                        case '-':
+                            if(currentHunk == null) {
+                                currentHunk = {
+                                    line,
+                                    end: line,
+                                    hash: crypto.createHash('sha256'),
+                                    preview: gitDiff.substring(startOfLine, endOfLine-1),
+                                    status: mostRecent ? 2 : 1
+                                };
+                                for(let i=0; i<DiffHunkElement.HUNK_CONTEXT_LINES; i++) {
+                                    const ctxLine = ctxLines[(ctxLinesIdx + i) % DiffHunkElement.HUNK_CONTEXT_LINES];
+                                    currentHunk.hash.update(gitDiff.substring(ctxLine[0], ctxLine[1]));
+                                }
+                            }
+                            if(mostRecent && (currentHunk.preview[0] === '-') || currentHunk.preview === '+') {
+                                currentHunk.preview = gitDiff.substring(startOfLine, endOfLine-1);
+                            }
+                            currentHunk.status |= mostRecent ? 2 : 1;
+                            currentHunk.hash.update(gitDiff.substring(startOfLine, endOfLine));
+                            break;
+                        case '@':
+                            gitDiff = gitDiff.substring(startOfLine);
+                            match = gitDiff.match(/@@ -\d+,\d+ \+(\d+),\d+ @@/);
+                            ctxLines = [];
+                            ctxLinesIdx = 0;
+                            line = parseInt(match![1]) - 1;
+                            startOfLine = gitDiff.indexOf('\n', match!.index) + 1;
+                            continue;
+                        default:
+                            inHunk = false;
+                            continue;
+                    }
+                    if(mostRecent) {
+                        startOfLine++;
+                        ctxLines[ctxLinesIdx] = [startOfLine, endOfLine];
+                        ctxLinesIdx = (ctxLinesIdx + 1) % DiffHunkElement.HUNK_CONTEXT_LINES
+                        line++;
+                        closingHunk.forEach(h => {
+                            if(h.end + DiffHunkElement.HUNK_CONTEXT_LINES === line) {
+                                for(let i=0; i<DiffHunkElement.HUNK_CONTEXT_LINES; i++) {
+                                    const ctxLine = ctxLines[(ctxLinesIdx + i) % DiffHunkElement.HUNK_CONTEXT_LINES];
+                                    h.hash.update(gitDiff.substring(ctxLine[0], ctxLine[1]));
+                                }
+                                const a:['M', 'D', 'A', 'M'] = ['M', 'D', 'A', 'M'];
+                                const hunkElement = new DiffHunkElement(
+                                    currentFile!,
+                                    h.line + 1,
+                                    h.preview,
+                                    h.hash.digest('hex').substring(0, 16),
+                                    a[h.status]
+                                );
+                                hunksMap.get(currentFile.dstAbsPath)?.push(hunkElement);
+                            }
+                        });
+                    }
+                    startOfLine = endOfLine;
+                }
+                gitDiff = gitDiff.substring(startOfLine);
+            } while(gitDiff);
+        } catch (e) {
+            this.log('Failed to retrieve diff hunks', e as Error);
+        }
+    
+        
+        // Comparer this.hunksMap avec hunksMap pour détecter les changements
+        let hunksHaveChanged = false;
+        if (!this.hunksMap || this.hunksMap.size !== hunksMap.size) {
+            hunksHaveChanged = true;
+        } else {
+            // Comparer les clés et les valeurs
+            for (const [filePath, newHunks] of hunksMap.entries()) {
+                const oldHunks = this.hunksMap.get(filePath);
+                if (!oldHunks || oldHunks.length !== newHunks.length) {
+                    hunksHaveChanged = true;
+                    break;
+                }
+                // Comparer les hash des hunks
+                for (let i = 0; i < newHunks.length; i++) {
+                    if (oldHunks[i].hash !== newHunks[i].hash) {
+                        hunksHaveChanged = true;
+                        break;
+                    }
+                }
+                if (hunksHaveChanged) {
+                    break;
+                }
+            }
+        }
+        
+        this.hunksMap = hunksMap;
+        this.log(`Loaded ${hunksMap.size} files with hunks`);
+
         // Always refresh when sorting by recently modified in list view, as file mtimes may have changed
         const needsRefreshForSorting = this.viewAsList && this.sortOrder === 'recentlyModified';
         
-        if (fireChangeEvents && (treeHasChanged || needsRefreshForSorting)) {
+        if (fireChangeEvents && (treeHasChanged || hunksHaveChanged || needsRefreshForSorting)) {
             this.log('Refreshing tree')
             this._onDidChangeTreeData.fire();
         }
@@ -1921,12 +1855,12 @@ function toTreeItem(element: Element, openChangesOnSelect: boolean, iconsMinimal
         }
         return item;
     } else if (element instanceof DiffHunkElement) {
-        const item = new TreeItem(element.firstLine || element.header || element.label);
-        item.description = `Lines ${element.newStart}-${element.newStart + element.newLines - 1}`;
+        const item = new TreeItem(element.label);
+        item.description = `Line ${element.newStart}`;
         item.tooltip = element.preview;
         item.contextValue = 'diffHunk';
-        item.id = `${element.fileElement.dstAbsPath}:${element.newStart}`;
-        item.iconPath = new ThemeIcon('diff');
+        item.id = `${element.fileElement.dstAbsPath}:${element.newStart}:${element.hash}`;
+        item.iconPath = path.join(gitIconRoot, toIconName(element) + '.svg');
         if (checkboxState !== undefined) {
             item.checkboxState = checkboxState;
         }
@@ -1973,7 +1907,7 @@ function toTreeItem(element: Element, openChangesOnSelect: boolean, iconsMinimal
     throw new Error('unsupported element type');
 }
 
-function toIconName(element: FileElement) {
+function toIconName(element: FileElement | DiffHunkElement): string {
     switch(element.status) {
         case 'U': return 'status-untracked';
         case 'A': return 'status-added';

--- a/src/treeProvider.ts
+++ b/src/treeProvider.ts
@@ -763,147 +763,159 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
         this.filesInsideTreeRoot = filesInsideTreeRoot;
         this.filesOutsideTreeRoot = filesOutsideTreeRoot;
 
-        // Récupérer les hunks pour tous les fichiers en un seul appel git diff
-        const hunksMap = new Map<string, DiffHunkElement[]>();
-        try {
-            const result = await this.repository!.exec(['diff', `-U${DiffHunkElement.HUNK_CONTEXT_LINES}`, '-w', this.mergeBase]);
-
-            let gitDiff = result.stdout;
-
-            type HunkContext = {line:number, end:number, hash:crypto.Hash, preview:string, status:number};
-            do {
-                let currentHunk: HunkContext | null = null;
-                let closingHunk: HunkContext[] = [];
-                let currentFile: FileElement | null = null;
-                let fileSection = gitDiff.indexOf('+++ b/');
-                gitDiff = gitDiff.substring(fileSection + 6);
-                let fileEnd = gitDiff.indexOf('\n');
-                let filename = gitDiff.substring(0, fileEnd);
-                const entry = diff.find(e => e.dstAbsPath.endsWith(filename));
-                if(!entry) {
-                    continue;
-                }
-                currentFile = new FileElement(
-                    entry.srcAbsPath,
-                    entry.dstAbsPath,
-                    path.relative(this.treeRoot, entry.dstAbsPath),
-                    entry.status,
-                    entry.isSubmodule
-                )
-                if (!hunksMap.has(currentFile.dstAbsPath)) {
-                    hunksMap.set(currentFile.dstAbsPath, []);
-                }
-                let match = gitDiff.match(/@@ -\d+,\d+ \+(\d+),\d+ @@/);
-                let ctxLines: [number, number][] = [];
-                let ctxLinesIdx = 0;
-                let line = parseInt(match![1]) - 1;
-                let startOfLine = gitDiff.indexOf('\n', match!.index) + 1;
-                let inHunk = true;
-                while(inHunk) {
-                    const endOfLine = gitDiff.indexOf('\n', startOfLine) + 1;
-                    let mostRecent = false;
-                    switch (gitDiff[startOfLine]) {
-                        case ' ':
-                            if(currentHunk) {
-                                currentHunk.end = line;
-                                closingHunk.push(currentHunk);
-                                currentHunk = null;
-                            }
-                            mostRecent = true;
-                            break;
-                        case '+':
-                            mostRecent = true;
-                        case '-':
-                            if(currentHunk == null) {
-                                currentHunk = {
-                                    line,
-                                    end: line,
-                                    hash: crypto.createHash('sha256'),
-                                    preview: gitDiff.substring(startOfLine, endOfLine-1),
-                                    status: mostRecent ? 2 : 1
-                                };
-                                for(let i=0; i<DiffHunkElement.HUNK_CONTEXT_LINES; i++) {
-                                    const ctxLine = ctxLines[(ctxLinesIdx + i) % DiffHunkElement.HUNK_CONTEXT_LINES];
-                                    currentHunk.hash.update(gitDiff.substring(ctxLine[0], ctxLine[1]));
-                                }
-                            }
-                            if(mostRecent && (currentHunk.preview[0] === '-') || currentHunk.preview === '+') {
-                                currentHunk.preview = gitDiff.substring(startOfLine, endOfLine-1);
-                            }
-                            currentHunk.status |= mostRecent ? 2 : 1;
-                            currentHunk.hash.update(gitDiff.substring(startOfLine, endOfLine));
-                            break;
-                        case '@':
-                            gitDiff = gitDiff.substring(startOfLine);
-                            match = gitDiff.match(/@@ -\d+,\d+ \+(\d+),\d+ @@/);
-                            ctxLines = [];
-                            ctxLinesIdx = 0;
-                            line = parseInt(match![1]) - 1;
-                            startOfLine = gitDiff.indexOf('\n', match!.index) + 1;
-                            continue;
-                        default:
-                            inHunk = false;
-                            continue;
-                    }
-                    if(mostRecent) {
-                        startOfLine++;
-                        ctxLines[ctxLinesIdx] = [startOfLine, endOfLine];
-                        ctxLinesIdx = (ctxLinesIdx + 1) % DiffHunkElement.HUNK_CONTEXT_LINES
-                        line++;
-                        closingHunk.forEach(h => {
-                            if(h.end + DiffHunkElement.HUNK_CONTEXT_LINES === line) {
-                                for(let i=0; i<DiffHunkElement.HUNK_CONTEXT_LINES; i++) {
-                                    const ctxLine = ctxLines[(ctxLinesIdx + i) % DiffHunkElement.HUNK_CONTEXT_LINES];
-                                    h.hash.update(gitDiff.substring(ctxLine[0], ctxLine[1]));
-                                }
-                                const a:['M', 'D', 'A', 'M'] = ['M', 'D', 'A', 'M'];
-                                const hunkElement = new DiffHunkElement(
-                                    currentFile!,
-                                    h.line + 1,
-                                    h.preview,
-                                    h.hash.digest('hex').substring(0, 16),
-                                    a[h.status]
-                                );
-                                hunksMap.get(currentFile.dstAbsPath)?.push(hunkElement);
-                            }
-                        });
-                    }
-                    startOfLine = endOfLine;
-                }
-                gitDiff = gitDiff.substring(startOfLine);
-            } while(gitDiff);
-        } catch (e) {
-            this.log('Failed to retrieve diff hunks', e as Error);
-        }
-    
-        
-        // Comparer this.hunksMap avec hunksMap pour détecter les changements
         let hunksHaveChanged = false;
-        if (!this.hunksMap || this.hunksMap.size !== hunksMap.size) {
-            hunksHaveChanged = true;
-        } else {
-            // Comparer les clés et les valeurs
-            for (const [filePath, newHunks] of hunksMap.entries()) {
-                const oldHunks = this.hunksMap.get(filePath);
-                if (!oldHunks || oldHunks.length !== newHunks.length) {
-                    hunksHaveChanged = true;
-                    break;
+        if(this.showDiffDetails) {
+            const hunksMap = new Map<string, DiffHunkElement[]>();
+            try {
+                type HunkContext = {line:number, end:number, hash:crypto.Hash, preview:string, status:number};
+
+                let gitDiff = (await this.repository!.exec(['diff', `-U${DiffHunkElement.HUNK_CONTEXT_LINES}`, '-w', this.mergeBase])).stdout;
+
+                while(gitDiff) {
+                    // jump to next file diff
+                    gitDiff = gitDiff.substring(gitDiff.indexOf('+++ b/') + 6);
+                    const filename = gitDiff.substring(0, gitDiff.indexOf('\n'));
+                    const entry = diff.find(e => e.dstAbsPath.endsWith(filename));
+                    if(!entry) {
+                        continue;
+                    }
+                    const currentFile = new FileElement(
+                        entry.srcAbsPath,
+                        entry.dstAbsPath,
+                        path.relative(this.treeRoot, entry.dstAbsPath),
+                        entry.status,
+                        entry.isSubmodule
+                    )
+                    if (!hunksMap.has(currentFile.dstAbsPath)) {
+                        hunksMap.set(currentFile.dstAbsPath, []);
+                    }
+
+                    let ctxLines: [number, number][] = []; // circular buffer of line start/end positions for context lines, used to compute hunk hash
+                    let ctxLinesIdx = 0;
+                    let currentHunk: HunkContext | null = null; // current hunk being parsed, null if currently parsing unchanged lines between hunks
+                    let closingHunk: HunkContext[] = []; // hunks parsed waiting for after context
+                    let match = gitDiff.match(/@@ -\d+(,\d+)? \+(\d+)(,\d+)? @@/);
+                    let line = parseInt(match![2]) - 1;
+                    let startOfLine = gitDiff.indexOf('\n', match!.index) + 1;
+                    let inHunk = true;
+
+                    function saveHunkCompleted(h: HunkContext) {
+                        if(h.end + DiffHunkElement.HUNK_CONTEXT_LINES === line) {
+                            for(let i=0; i<DiffHunkElement.HUNK_CONTEXT_LINES; i++) {
+                                const ctxLine = ctxLines[(ctxLinesIdx + i) % DiffHunkElement.HUNK_CONTEXT_LINES];
+                                h.hash.update(gitDiff.substring(ctxLine[0], ctxLine[1]));
+                            }
+                            const status2char:['M', 'D', 'A', 'M'] = ['M', 'D', 'A', 'M'];
+                            const hunkElement = new DiffHunkElement(
+                                currentFile,
+                                h.line + 1,
+                                h.preview.substring(1),
+                                h.hash.digest('hex').substring(0, 16),
+                                status2char[h.status]
+                            );
+                            hunksMap.get(currentFile.dstAbsPath)?.push(hunkElement);
+                            return false;
+                        }
+                        return true;
+                    }
+
+                    while(inHunk) {
+                        const endOfLine = gitDiff.indexOf('\n', startOfLine) + 1;
+                        let mostRecent = false; // true if current line is context or addition
+                        switch (gitDiff[startOfLine]) {
+                            case ' ':
+                                if(currentHunk) {
+                                    currentHunk.end = line;
+                                    closingHunk.push(currentHunk);
+                                    currentHunk = null;
+                                }
+                                mostRecent = true;
+                                break;
+                            case '+':
+                                mostRecent = true;
+                            case '-':
+                                if(currentHunk == null) {
+                                    currentHunk = {
+                                        line,
+                                        end: line,
+                                        hash: crypto.createHash('sha1'),
+                                        preview: gitDiff.substring(startOfLine, endOfLine-1),
+                                        status: mostRecent ? 2 : 1,
+                                    };
+                                    for(let i=0; i<DiffHunkElement.HUNK_CONTEXT_LINES; i++) {
+                                        const ctxLine = ctxLines[(ctxLinesIdx + i) % DiffHunkElement.HUNK_CONTEXT_LINES];
+                                        currentHunk.hash.update(gitDiff.substring(ctxLine[0], ctxLine[1]));
+                                    }
+                                }
+                                if(mostRecent && (currentHunk.preview[0] === '-') || currentHunk.preview === '+') {
+                                    currentHunk.preview = gitDiff.substring(startOfLine, endOfLine-1);
+                                }
+                                currentHunk.status |= mostRecent ? 2 : 1;
+                                currentHunk.hash.update(gitDiff.substring(startOfLine, endOfLine));
+                                break;
+                            case '@':
+                                if(currentHunk) {
+                                    currentHunk.end = line;
+                                    saveHunkCompleted(currentHunk);
+                                }
+                                gitDiff = gitDiff.substring(startOfLine);
+                                match = gitDiff.match(/@@ -\d+(,\d+)? \+(\d+)(,\d+)? @@/);
+                                ctxLines = [];
+                                ctxLinesIdx = 0;
+                                currentHunk = null;
+                                closingHunk = [];
+                                line = parseInt(match![2]) - 1;
+                                startOfLine = gitDiff.indexOf('\n', match!.index) + 1;
+                                continue; // same file, reset hunk vars and continue parsing
+                            default:
+                                if(currentHunk) {
+                                    currentHunk.end = line;
+                                    saveHunkCompleted(currentHunk);
+                                }
+                                inHunk = false;
+                                continue; // end of hunks for this file
+                        }
+                        if(mostRecent) {
+                            ctxLines[ctxLinesIdx] = [startOfLine + 1, endOfLine];
+                            ctxLinesIdx = (ctxLinesIdx + 1) % DiffHunkElement.HUNK_CONTEXT_LINES
+                            line++;
+                            closingHunk = closingHunk.filter(saveHunkCompleted);
+                        }
+                        startOfLine = endOfLine;
+                    }
+                    gitDiff = gitDiff.substring(startOfLine);
                 }
-                // Comparer les hash des hunks
-                for (let i = 0; i < newHunks.length; i++) {
-                    if (oldHunks[i].hash !== newHunks[i].hash) {
+            } catch (e) {
+                this.log('Failed to retrieve diff hunks', e as Error);
+            }
+            console.log('hunksMap', hunksMap.size, hunksMap);
+
+            if (!this.hunksMap || this.hunksMap.size !== hunksMap.size) {
+                hunksHaveChanged = true;
+            } else {
+                // Comparer les clés et les valeurs
+                for (const [filePath, newHunks] of hunksMap.entries()) {
+                    const oldHunks = this.hunksMap.get(filePath);
+                    if (!oldHunks || oldHunks.length !== newHunks.length) {
                         hunksHaveChanged = true;
                         break;
                     }
-                }
-                if (hunksHaveChanged) {
-                    break;
+                    // Comparer les hash des hunks
+                    for (let i = 0; i < newHunks.length; i++) {
+                        if (oldHunks[i].hash !== newHunks[i].hash) {
+                            hunksHaveChanged = true;
+                            break;
+                        }
+                    }
+                    if (hunksHaveChanged) {
+                        break;
+                    }
                 }
             }
+            
+            this.hunksMap = hunksMap;
+            this.log(`Loaded ${hunksMap.size} files with hunks`);
         }
-        
-        this.hunksMap = hunksMap;
-        this.log(`Loaded ${hunksMap.size} files with hunks`);
 
         // Always refresh when sorting by recently modified in list view, as file mtimes may have changed
         const needsRefreshForSorting = this.viewAsList && this.sortOrder === 'recentlyModified';

--- a/src/treeProvider.ts
+++ b/src/treeProvider.ts
@@ -31,11 +31,6 @@ const STATUS_SORT_ORDER: { [key: string]: number } = {
     'T': 6  // Type change
 };
 
-interface CheckboxStateInfo {
-    state: TreeItemCheckboxState;
-    timestamp: number; // When the checkbox was checked
-}
-
 class FileElement implements IDiffStatus {
     modificationDate?: Date;
 
@@ -145,7 +140,6 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
     private compactFolders: boolean;
     private showCheckboxes: boolean;
     private showDiffDetails: boolean;
-    private resetCheckboxOnFileChange: boolean;
     private omitUntrackedFiles: boolean;
     private omitUnstagedChanges: boolean;
     private sortOrder: SortOrder;
@@ -178,7 +172,6 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
     // UI state
     private treeView: TreeView<Element>;
     private isPaused: boolean;
-    private checkboxStates: Map<string, CheckboxStateInfo> = new Map<string, CheckboxStateInfo>();
 
     // Other
     private readonly disposables: Disposable[] = [];
@@ -283,7 +276,6 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
             window.showErrorMessage(`${msg}: ${e.message}`);
             return;
         }
-        this.checkboxStates.clear();
         this._onDidChangeTreeData.fire();
     }
 
@@ -353,10 +345,6 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
         const diff: DiffHunkElement[][] = [[],[]];
         for (const [element, state] of e.items) {
             if (element instanceof FileElement) {
-                this.checkboxStates.set(element.dstAbsPath, {
-                    state: state,
-                    timestamp: Date.now()
-                });
                 const childHunkPresent = e.items.some(([nextElement, _]) => nextElement instanceof DiffHunkElement && nextElement.fileElement === element);
                 if (!childHunkPresent) {
                     // process only if hunk of these files are not already included in event
@@ -364,10 +352,6 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
                     diff[state].push(...hunks);
                 }
             } else if (element instanceof FolderElement) {
-                this.checkboxStates.set(element.dstAbsPath, {
-                    state: state,
-                    timestamp: Date.now()
-                });
                 const childFilePresent = e.items.some(([nextElement, _]) => nextElement instanceof FileElement && nextElement.dstAbsPath.includes(element.dstAbsPath));
                 if (!childFilePresent) {
                     const files = element.useFilesOutsideTreeRoot ? this.filesOutsideTreeRoot : this.filesInsideTreeRoot;
@@ -589,7 +573,6 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
         this.compactFolders = config.get<boolean>('compactFolders', false);
         this.showCheckboxes = config.get<boolean>('showCheckboxes', false);
         this.showDiffDetails = config.get<boolean>('showDiffDetails', true);
-        this.resetCheckboxOnFileChange = config.get<boolean>('resetCheckboxOnFileChange', false);
         this.omitUntrackedFiles = config.get<boolean>('omitUntrackedFiles', false);
         this.omitUnstagedChanges = config.get<boolean>('omitUnstagedChanges', false);
         this.sortOrder = config.get<SortOrder>('sortOrder', 'path');
@@ -644,12 +627,6 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
     }
 
     private async computeFileCheckboxState(file: FileElement): Promise<TreeItemCheckboxState> {
-        // Check if user explicitly set state on this file
-        const explicitState = this.checkboxStates.get(file.dstAbsPath);
-        if (explicitState) {
-            return explicitState.state;
-        }
-        
         let hasHunks = false;
         const hunks = await this.getDiffHunks(file);
         for (const hunkElement of hunks) {
@@ -662,13 +639,7 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
     }
 
     private async computeFolderCheckboxState(folder: FolderElement): Promise<TreeItemCheckboxState> {
-        // Check if user explicitly set state on this folder
-        const explicitState = this.checkboxStates.get(folder.dstAbsPath);
-        if (explicitState) {
-            return explicitState.state;
-        }
-        
-        // Otherwise derive from files: folder is checked only if ALL files under it are checked
+        // Derive from files: folder is checked only if ALL files under it are checked
         const files = folder.useFilesOutsideTreeRoot ? this.filesOutsideTreeRoot : this.filesInsideTreeRoot;
         let hasFiles = false;
         
@@ -677,14 +648,9 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
             if (folderPath === folder.dstAbsPath || folderPath.startsWith(folder.dstAbsPath + path.sep)) {
                 for (const file of fileEntries) {
                     hasFiles = true;
-                    const stateInfo = this.checkboxStates.get(file.dstAbsPath);
-                    if(!stateInfo) {
-                        if(await this.computeFileCheckboxState(new FileElement(file.srcAbsPath, file.dstAbsPath, 
-                            path.relative(this.treeRoot, file.dstAbsPath), file.status, file.isSubmodule)) !== TreeItemCheckboxState.Checked) {
-                            return TreeItemCheckboxState.Unchecked;
-                        }
-                    }
-                    else if (stateInfo.state !== TreeItemCheckboxState.Checked) {
+                    const fileState = await this.computeFileCheckboxState(new FileElement(file.srcAbsPath, file.dstAbsPath, 
+                        path.relative(this.treeRoot, file.dstAbsPath), file.status, file.isSubmodule));
+                    if (fileState !== TreeItemCheckboxState.Checked) {
                         return TreeItemCheckboxState.Unchecked;
                     }
                 }
@@ -896,7 +862,6 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
             }
             if (this.headName !== headName) {
                 this.log(`HEAD ref updated: ${this.headName} -> ${headName}`);
-                this.checkboxStates.clear();
             }
             if (this.headCommit !== headCommit) {
                 this.log(`HEAD ref commit updated: ${this.headCommit} -> ${headCommit}`);
@@ -932,8 +897,6 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
         this.log(`${diff.length} diff entries (${untrackedCount} untracked)`);
 
         const newFilePaths = new Set<string>();
-        // Collect files that need mtime checking for async batch processing
-        const filesToCheckMtime: Array<{filePath: string, stateInfo: CheckboxStateInfo}> = [];
         
         for (const entry of diff) {
             const folder = path.dirname(entry.dstAbsPath);
@@ -960,54 +923,6 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
 
             // Track new file paths
             newFilePaths.add(entry.dstAbsPath);
-            
-            // Collect checked files for mtime checking to reset if modified after being checked
-            if (this.resetCheckboxOnFileChange) {
-                const stateInfo = this.checkboxStates.get(entry.dstAbsPath);
-                if (stateInfo && stateInfo.state === TreeItemCheckboxState.Checked) {
-                    filesToCheckMtime.push({filePath: entry.dstAbsPath, stateInfo});
-                }
-            }
-        }
-
-        // Check file modification times asynchronously in parallel
-        if (this.resetCheckboxOnFileChange && filesToCheckMtime.length > 0) {
-            const statPromises = filesToCheckMtime.map(async ({filePath, stateInfo}) => {
-                try {
-                    const stats = await fs.promises.stat(filePath);
-                    const fileMtime = stats.mtimeMs;
-                    
-                    // If file was modified after checkbox was checked, reset it
-                    if (fileMtime > stateInfo.timestamp) {
-                        return filePath;
-                    }
-                } catch (error: unknown) {
-                    // File might be deleted or inaccessible - this is expected in some cases
-                    const errorMessage = error instanceof Error ? error.message : String(error);
-                    this.log(`Could not stat file for checkbox reset check: ${filePath}: ${errorMessage}`);
-                }
-                return null;
-            });
-            
-            const pathsToReset = await Promise.all(statPromises);
-            const actualPathsToReset = pathsToReset.filter((filePath): filePath is string => filePath !== null);
-            actualPathsToReset.forEach(filePath => this.checkboxStates.delete(filePath));
-            
-            // Fire tree refresh to update checkbox UI
-            if (actualPathsToReset.length > 0) {
-                this._onDidChangeTreeData.fire();
-            }
-        }
-
-        // Clear checkbox state for files that no longer exist in the diff
-        const pathsToDelete: string[] = [];
-        for (const [filePath] of this.checkboxStates) {
-            if (!newFilePaths.has(filePath)) {
-                pathsToDelete.push(filePath);
-            }
-        }
-        for (const filePath of pathsToDelete) {
-            this.checkboxStates.delete(filePath);
         }
 
         let treeHasChanged = false;

--- a/src/treeProvider.ts
+++ b/src/treeProvider.ts
@@ -420,15 +420,13 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
         try {
             const repoName = path.basename(this.repository.root);
             const storagePath = path.join(this.storageUri.fsPath, `checked-hunks-${repoName}-${this.mergeBase}.json`);
-            
-            // Lire le fichier existant
+
             let data: { [filepath: string]: string[] } = {};
             if (fs.existsSync(storagePath)) {
                 const content = await fs.promises.readFile(storagePath, 'utf-8');
                 data = JSON.parse(content);
             }
-            
-            // Mettre à jour les hunks
+
             for (const element of elements) {
                 const filepath = element.fileElement.dstAbsPath;
                 const hash = element.hash;
@@ -436,21 +434,19 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
                 if (!data[filepath]) {
                     data[filepath] = [];
                 }
-                
+
                 if (added) {
-                    // Ajouter le hash s'il n'existe pas déjà
                     if (!data[filepath].includes(hash)) {
                         data[filepath].push(hash);
                     }
                 } else {
-                    // Retirer le hash
                     data[filepath] = data[filepath].filter(h => h !== hash);
                     if (data[filepath].length === 0) {
                         delete data[filepath];
                     }
                 }
             }
-            
+
             await fs.promises.mkdir(path.dirname(storagePath), { recursive: true });
             await fs.promises.writeFile(storagePath, JSON.stringify(data, null, 2), 'utf-8');
             this.log(`Saved ${added ? 'added' : 'removed'} ${elements.length} hunks to ${storagePath}`);
@@ -974,14 +970,12 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
             if (!this.hunksMap || this.hunksMap.size !== hunksMap.size) {
                 hunksHaveChanged = true;
             } else {
-                // Comparer les clés et les valeurs
                 for (const [filePath, newHunks] of hunksMap.entries()) {
                     const oldHunks = this.hunksMap.get(filePath);
                     if (!oldHunks || oldHunks.length !== newHunks.length) {
                         hunksHaveChanged = true;
                         break;
                     }
-                    // Comparer les hash des hunks
                     for (let i = 0; i < newHunks.length; i++) {
                         if (oldHunks[i].hash !== newHunks[i].hash) {
                             hunksHaveChanged = true;

--- a/src/treeProvider.ts
+++ b/src/treeProvider.ts
@@ -5,7 +5,7 @@ import * as crypto from 'crypto'
 
 import { TreeDataProvider, TreeItem, TreeItemCollapsibleState,
          Uri, Disposable, EventEmitter, TextDocumentShowOptions,
-         QuickPickItem, ProgressLocation, Memento, OutputChannel,
+         QuickPickItem, ProgressLocation, Memento, OutputChannel, Range,
          workspace, commands, window, env, WorkspaceFoldersChangeEvent, TreeView, ThemeIcon, TreeItemCheckboxState, TreeCheckboxChangeEvent, authentication } from 'vscode'
 import { NAMESPACE } from './constants'
 import { Repository, Git } from './git/git'
@@ -1206,36 +1206,21 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
         return diffStatus;
     }
 
-    async openChanges(fileEntry?: FileElement) {
+    async openChanges(fileEntry?: FileElement | DiffHunkElement) {
+        const options: TextDocumentShowOptions = {preview: true};
+        if(fileEntry instanceof DiffHunkElement) {
+            options.selection = new Range(fileEntry.newStart - 1, 0, fileEntry.newStart - 1, 0);
+            options.preserveFocus = false;
+            fileEntry = fileEntry.fileElement;
+        }
         const diffStatus = this.getDiffStatus(fileEntry);
         if (!diffStatus) {
             return;
         }
-        await this.doOpenChanges(diffStatus.srcAbsPath, diffStatus.dstAbsPath, diffStatus.status);
+        await this.doOpenChanges(diffStatus.srcAbsPath, diffStatus.dstAbsPath, diffStatus.status, options);
     }
 
-    async openChangesAtLine(hunkElement: DiffHunkElement) {
-        const fileElement = hunkElement.fileElement;
-        await this.doOpenChanges(fileElement.srcAbsPath, fileElement.dstAbsPath, fileElement.status);
-        
-        // Attendre un peu que l'éditeur s'ouvre
-        await new Promise(resolve => setTimeout(resolve, 100));
-        
-        // Naviguer vers la ligne dans l'éditeur actif
-        const editor = window.activeTextEditor;
-        if (editor) {
-            const line = hunkElement.newStart - 1; // Les lignes sont 0-indexées dans l'API
-            const position = new (await import('vscode')).Position(line, 0);
-            const range = new (await import('vscode')).Range(position, position);
-            const selection = new (await import('vscode')).Selection(position, position);
-            const TextEditorRevealType = (await import('vscode')).TextEditorRevealType;
-            
-            editor.selection = selection;
-            editor.revealRange(range, TextEditorRevealType.InCenter);
-        }
-    }
-
-    async doOpenChanges(srcAbsPath: string, dstAbsPath: string, status: StatusCode, preview=true) {
+    async doOpenChanges(srcAbsPath: string, dstAbsPath: string, status: StatusCode, options: TextDocumentShowOptions) {
         const right = Uri.file(dstAbsPath);
         const left = this.gitApi.toGitUri(Uri.file(srcAbsPath), this.mergeBase);
 
@@ -1246,9 +1231,6 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
             return commands.executeCommand('vscode.open', left);
         }
 
-        const options: TextDocumentShowOptions = {
-            preview: preview
-        };
         const filename = path.basename(dstAbsPath);
         return await commands.executeCommand('vscode.diff',
             left, right, filename + " (Working Tree)", options);
@@ -1257,7 +1239,7 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
     openAllChanges(entry: RefElement | RepoRootElement | FolderElement | undefined) {
         const withinFolder = entry instanceof FolderElement ? entry.dstAbsPath : undefined;
         for (const file of this.iterFiles(withinFolder)) {
-            this.doOpenChanges(file.srcAbsPath, file.dstAbsPath, file.status, false);
+            this.doOpenChanges(file.srcAbsPath, file.dstAbsPath, file.status, { preview: false });
         }
     }
 
@@ -1876,9 +1858,8 @@ function toTreeItem(element: Element, openChangesOnSelect: boolean, iconsMinimal
         if (checkboxState !== undefined) {
             item.checkboxState = checkboxState;
         }
-        // Commande pour ouvrir le diff à la ligne spécifique
         item.command = {
-            command: NAMESPACE + '.openChangesAtLine',
+            command: NAMESPACE + '.openChanges',
             arguments: [element],
             title: ''
         };

--- a/src/treeProvider.ts
+++ b/src/treeProvider.ts
@@ -51,6 +51,25 @@ class FileElement implements IDiffStatus {
     }
 }
 
+class DiffHunkElement {
+    constructor(
+        public fileElement: FileElement,
+        public oldStart: number,
+        public oldLines: number,
+        public newStart: number,
+        public newLines: number,
+        public header: string,
+        public preview: string,
+        public firstLine: string,
+        public lines: string[] = []) {}
+
+    get label(): string {
+        return `@@ -${this.oldStart},${this.oldLines} +${this.newStart},${this.newLines} @@`;
+    }
+
+    
+}
+
 class FolderElement {
     constructor(
         public label: string,
@@ -68,7 +87,7 @@ class RefElement {
     constructor(public repositoryRoot: string, public refName: string, public hasChildren: boolean) {}
 }
 
-export type Element = FileElement | FolderElement | RepoRootElement | RefElement
+export type Element = FileElement | FolderElement | RepoRootElement | RefElement | DiffHunkElement
 type FileSystemElement = FileElement | FolderElement
 
 class ChangeBaseRefItem implements QuickPickItem {
@@ -164,7 +183,7 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
     private readonly disposables: Disposable[] = [];
 
     constructor(private readonly git: Git, private readonly gitApi: GitAPI, private readonly outputChannel: OutputChannel, private readonly globalState: Memento,
-                private readonly asAbsolutePath: (relPath: string) => string) {
+                private readonly asAbsolutePath: (relPath: string) => string, private readonly storageUri: Uri) {
         this.readConfig();
     }
 
@@ -330,13 +349,209 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
     }
 
     private async handleChangeCheckboxState(e: TreeCheckboxChangeEvent<Element>) {
-        for (let [element, state] of e.items) {
-            if (element instanceof FileElement || element instanceof FolderElement) {
+        const diff: DiffHunkElement[][] = [[],[]];
+        for (const [element, state] of e.items) {
+            if (element instanceof FileElement) {
                 this.checkboxStates.set(element.dstAbsPath, {
                     state: state,
                     timestamp: Date.now()
                 });
+                const childHunkPresent = e.items.some(([nextElement, _]) => nextElement instanceof DiffHunkElement && nextElement.fileElement === element);
+                if (!childHunkPresent) {
+                    // process only if hunk of these files are not already included in event
+                    const hunks = await this.getDiffHunks(element);
+                    diff[state].push(...hunks);
+                }
+            } else if (element instanceof FolderElement) {
+                this.checkboxStates.set(element.dstAbsPath, {
+                    state: state,
+                    timestamp: Date.now()
+                });
+                const childFilePresent = e.items.some(([nextElement, _]) => nextElement instanceof FileElement && nextElement.dstAbsPath.includes(element.dstAbsPath));
+                if (!childFilePresent) {
+                    const files = element.useFilesOutsideTreeRoot ? this.filesOutsideTreeRoot : this.filesInsideTreeRoot;
+                    for (const [folderPath, fileEntries] of files.entries()) {
+                        if (folderPath === element.dstAbsPath || folderPath.startsWith(element.dstAbsPath + path.sep)) {
+                            for (const file of fileEntries) {
+                                const fileElement = new FileElement(file.srcAbsPath, file.dstAbsPath, 
+                                    path.relative(this.treeRoot, file.dstAbsPath), file.status, file.isSubmodule);
+                                const hunks = await this.getDiffHunks(fileElement);
+                                diff[state].push(...hunks);
+                            }
+                        }
+                    }
+                }
+            } else if (element instanceof DiffHunkElement) {
+                diff[state].push(element);
             }
+        }
+        
+        await this.saveCheckedHunks(diff[0], false);
+        await this.saveCheckedHunks(diff[1], true);
+    }
+
+    private isHunkChecked(element: DiffHunkElement): boolean {
+        if (!this.storageUri || !this.repository) {
+            return false;
+        }
+        try {
+            const repoName = path.basename(this.repository.root);
+            const storagePath = path.join(this.storageUri.fsPath, `checked-hunks-${repoName}.diff`);
+            
+            if (!fs.existsSync(storagePath)) {
+                return false;
+            }
+            
+            const content = fs.readFileSync(storagePath, 'utf-8');
+            const lines = content.split('\n');
+            
+            let currentFile = '';
+            const targetFile = element.fileElement.dstAbsPath;
+            const targetLine = element.newStart;
+            
+            for (const line of lines) {
+                if (line.startsWith('diff --git')) {
+                    const match = line.match(/b\/(.+)$/);
+                    if (match) {
+                        currentFile = match[1];
+                    }
+                } else if (line.startsWith('@@') && currentFile === targetFile) {
+                    const match = line.match(/^@@ -\d+,\d+ \+(\d+),\d+/);
+                    if (match) {
+                        const lineNum = parseInt(match[1]);
+                        if (lineNum === targetLine) {
+                            return true;
+                        }
+                    }
+                }
+            }
+            return false;
+        } catch (error) {
+            return false;
+        }
+    }
+
+    private async saveCheckedHunks(elements: DiffHunkElement[], added: boolean): Promise<void> {
+        if (!this.storageUri || !this.repository || elements.length === 0) {
+            return;
+        }
+        try {
+            const repoName = path.basename(this.repository.root);
+            const storagePath = path.join(this.storageUri.fsPath, `checked-hunks-${repoName}.diff`);
+            
+            // Structure pour stocker les hunks par fichier avec leur contenu complet
+            const fileHunks = new Map<string, Array<{oldStart: number, oldLines: number, newStart: number, newLines: number, header: string, lines: string[]}>>();
+            
+            // Lire le fichier existant et parser le format complet
+            if (fs.existsSync(storagePath)) {
+                const content = await fs.promises.readFile(storagePath, 'utf-8');
+                const lines = content.split('\n');
+                let currentFile = '';
+                let currentHunk: {oldStart: number, oldLines: number, newStart: number, newLines: number, header: string, lines: string[]} | null = null;
+                const hunkHeaderRegex = /^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@(.*)$/;
+                
+                for (const line of lines) {
+                    if (line.startsWith('diff --git')) {
+                        if (currentHunk && currentFile) {
+                            if (!fileHunks.has(currentFile)) {
+                                fileHunks.set(currentFile, []);
+                            }
+                            fileHunks.get(currentFile)!.push(currentHunk);
+                        }
+                        const match = line.match(/b\/(.+)$/);
+                        if (match) {
+                            currentFile = match[1];
+                            currentHunk = null;
+                        }
+                    } else if (line.startsWith('---') || line.startsWith('+++')) {
+                        // Ignorer les headers de fichier
+                        continue;
+                    } else if (line.startsWith('@@')) {
+                        if (currentHunk && currentFile) {
+                            if (!fileHunks.has(currentFile)) {
+                                fileHunks.set(currentFile, []);
+                            }
+                            fileHunks.get(currentFile)!.push(currentHunk);
+                        }
+                        const match = hunkHeaderRegex.exec(line);
+                        if (match) {
+                            const oldStart = parseInt(match[1]);
+                            const oldLines = match[2] ? parseInt(match[2]) : 1;
+                            const newStart = parseInt(match[3]);
+                            const newLines = match[4] ? parseInt(match[4]) : 1;
+                            const header = match[5];
+                            currentHunk = {oldStart, oldLines, newStart, newLines, header, lines: []};
+                        }
+                    } else if (currentHunk && (line.startsWith('+') || line.startsWith('-') || line.startsWith(' '))) {
+                        currentHunk.lines.push(line);
+                    }
+                }
+                
+                // Ajouter le dernier hunk
+                if (currentHunk && currentFile) {
+                    if (!fileHunks.has(currentFile)) {
+                        fileHunks.set(currentFile, []);
+                    }
+                    fileHunks.get(currentFile)!.push(currentHunk);
+                }
+            }
+            
+            // Traiter chaque élément du tableau
+            for (const element of elements) {
+                const filepath = element.fileElement.dstAbsPath;
+                const targetNewStart = element.newStart;
+                
+                if (!fileHunks.has(filepath)) {
+                    fileHunks.set(filepath, []);
+                }
+                
+                const hunks = fileHunks.get(filepath)!;
+                const existingIndex = hunks.findIndex(h => h.newStart === targetNewStart);
+                
+                if (added) {
+                    // Ajouter le hunk s'il n'existe pas déjà
+                    if (existingIndex < 0) {
+                        hunks.push({
+                            oldStart: element.oldStart,
+                            oldLines: element.oldLines,
+                            newStart: element.newStart,
+                            newLines: element.newLines,
+                            header: element.header,
+                            lines: element.lines
+                        });
+                        // Trier les hunks par position
+                        hunks.sort((a, b) => a.newStart - b.newStart);
+                    }
+                } else {
+                    // Retirer le hunk
+                    if (existingIndex >= 0) {
+                        hunks.splice(existingIndex, 1);
+                        if (hunks.length === 0) {
+                            fileHunks.delete(filepath);
+                        }
+                    }
+                }
+            }
+            
+            // Générer le fichier diff au format git diff complet
+            const diffLines: string[] = [];
+            for (const [filepath, hunks] of fileHunks) {
+                if (hunks.length > 0) {
+                    diffLines.push(`diff --git a/${filepath} b/${filepath}`);
+                    diffLines.push(`--- a/${filepath}`);
+                    diffLines.push(`+++ b/${filepath}`);
+                    
+                    for (const hunk of hunks) {
+                        diffLines.push(`@@ -${hunk.oldStart},${hunk.oldLines} +${hunk.newStart},${hunk.newLines} @@${hunk.header}`);
+                        diffLines.push(...hunk.lines);
+                    }
+                }
+            }
+            
+            await fs.promises.mkdir(path.dirname(storagePath), { recursive: true });
+            await fs.promises.writeFile(storagePath, diffLines.join('\n'), 'utf-8');
+        } catch (error) {
+            this.log('Failed to save checked hunks', error as Error);
         }
     }
 
@@ -410,21 +625,41 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
         this.globalState.update('baseRef_' + this.repoRoot, baseRef);
     }
 
-    getTreeItem(element: Element): TreeItem {
+    async getTreeItem(element: Element): Promise<TreeItem> {
         let checkboxState: TreeItemCheckboxState | undefined;
         if (this.showCheckboxes) {
             if (element instanceof FileElement) {
-                const stateInfo = this.checkboxStates.get(element.dstAbsPath);
-                checkboxState = stateInfo?.state ?? TreeItemCheckboxState.Unchecked;
+                // Compute file state from hunks: checked if all hunks are checked
+                checkboxState = await this.computeFileCheckboxState(element);
             } else if (element instanceof FolderElement) {
                 // Compute folder state from children: checked if all children are checked
-                checkboxState = this.computeFolderCheckboxState(element);
+                checkboxState = await this.computeFolderCheckboxState(element);
+            } else if (element instanceof DiffHunkElement) {
+                checkboxState = this.isHunkChecked(element) ? TreeItemCheckboxState.Checked : TreeItemCheckboxState.Unchecked;
             }
         }
         return toTreeItem(element, this.openChangesOnSelect, this.iconsMinimal, this.showCollapsed, this.viewAsList, checkboxState, this.asAbsolutePath);
     }
 
-    private computeFolderCheckboxState(folder: FolderElement): TreeItemCheckboxState {
+    private async computeFileCheckboxState(file: FileElement): Promise<TreeItemCheckboxState> {
+        // Check if user explicitly set state on this file
+        const explicitState = this.checkboxStates.get(file.dstAbsPath);
+        if (explicitState) {
+            return explicitState.state;
+        }
+        
+        let hasHunks = false;
+        const hunks = await this.getDiffHunks(file);
+        for (const hunkElement of hunks) {
+            if (!this.isHunkChecked(hunkElement)) {
+                return TreeItemCheckboxState.Unchecked;
+            }
+            hasHunks = true;
+        }
+        return hasHunks ? TreeItemCheckboxState.Checked : TreeItemCheckboxState.Unchecked;
+    }
+
+    private async computeFolderCheckboxState(folder: FolderElement): Promise<TreeItemCheckboxState> {
         // Check if user explicitly set state on this folder
         const explicitState = this.checkboxStates.get(folder.dstAbsPath);
         if (explicitState) {
@@ -434,7 +669,6 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
         // Otherwise derive from files: folder is checked only if ALL files under it are checked
         const files = folder.useFilesOutsideTreeRoot ? this.filesOutsideTreeRoot : this.filesInsideTreeRoot;
         let hasFiles = false;
-        let allChecked = true;
         
         for (const [folderPath, fileEntries] of files.entries()) {
             // Check if this folder is under the target folder
@@ -442,16 +676,20 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
                 for (const file of fileEntries) {
                     hasFiles = true;
                     const stateInfo = this.checkboxStates.get(file.dstAbsPath);
-                    if (!stateInfo || stateInfo.state !== TreeItemCheckboxState.Checked) {
-                        allChecked = false;
-                        break;
+                    if(!stateInfo) {
+                        if(await this.computeFileCheckboxState(new FileElement(file.srcAbsPath, file.dstAbsPath, 
+                            path.relative(this.treeRoot, file.dstAbsPath), file.status, file.isSubmodule)) !== TreeItemCheckboxState.Checked) {
+                            return TreeItemCheckboxState.Unchecked;
+                        }
+                    }
+                    else if (stateInfo.state !== TreeItemCheckboxState.Checked) {
+                        return TreeItemCheckboxState.Unchecked;
                     }
                 }
-                if (!allChecked) break;
             }
         }
         
-        return (hasFiles && allChecked) ? TreeItemCheckboxState.Checked : TreeItemCheckboxState.Unchecked;
+        return hasFiles ? TreeItemCheckboxState.Checked : TreeItemCheckboxState.Unchecked;
     }
 
     async getChildren(element?: Element): Promise<Element[]> {
@@ -481,9 +719,124 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
             return entries.concat(this.getFileSystemEntries(this.treeRoot, false));
         } else if (element instanceof FolderElement) {
             return this.getFileSystemEntries(element.dstAbsPath, element.useFilesOutsideTreeRoot);
+        } else if (element instanceof FileElement) {
+            // Return diff hunks for this file
+            return await this.getDiffHunks(element);
         }
         assert(false, "unsupported element type");
         return [];
+    }
+
+    private async getDiffHunks(fileElement: FileElement): Promise<DiffHunkElement[]> {
+        if (fileElement.status === 'U' || fileElement.status === 'A' || fileElement.status === 'D') {
+            // Pour les fichiers non trackés, ajoutés ou supprimés, pas de hunks détaillés
+            return [];
+        }
+
+        try {
+            const dstRelPath = path.relative(this.repository!.root, fileElement.dstAbsPath);
+            // Utiliser git diff avec -U1 (1 ligne de contexte) et -w (ignorer whitespaces)
+            const result = await this.repository!.exec(['diff', '-U0', '-w', this.mergeBase, '--', dstRelPath]);
+            
+            const parsedHunks = this.parseDiffHunks(fileElement, result.stdout);
+            this.log(`Parsed ${parsedHunks.length} hunks for ${fileElement.dstAbsPath}`);
+            return parsedHunks;
+        } catch (e) {
+            this.log('Error getting diff hunks', e as Error);
+            return [];
+        }
+    }
+
+    private parseDiffHunks(fileElement: FileElement, diffOutput: string): DiffHunkElement[] {
+        const hunks: DiffHunkElement[] = [];
+        const lines = diffOutput.split('\n');
+        
+        // Regex pour extraire les informations du header de hunk: @@ -oldStart,oldLines +newStart,newLines @@
+        const hunkHeaderRegex = /^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@(.*)$/;
+        
+        let currentHunk: { oldStart: number; oldLines: number; newStart: number; newLines: number; header: string; lines: string[] } | null = null;
+        let hunkCount = 0;
+        
+        for (let i = 0; i < lines.length; i++) {
+            const line = lines[i];
+            const match = hunkHeaderRegex.exec(line);
+            
+            if (match) {
+                hunkCount++;
+                this.log(`Found hunk header #${hunkCount}: ${line}`);
+                
+                // Sauvegarder le hunk précédent s'il existe
+                if (currentHunk) {
+                    const preview = currentHunk.lines.slice(0, 3).join('\n');
+                    // Trouver la première ligne avec + ou -
+                    const firstAddedLine = currentHunk.lines.find(l => l.startsWith('+') && !l.startsWith('+++'));
+                    const firstRemovedLine = currentHunk.lines.find(l => l.startsWith('-') && !l.startsWith('---'));
+                    let firstLine = '';
+                    if (firstAddedLine) {
+                        firstLine = firstAddedLine.substring(1).trim();
+                    } else if (firstRemovedLine) {
+                        firstLine = ' - ' + firstRemovedLine.substring(1).trim();
+                    }
+                    hunks.push(new DiffHunkElement(
+                        fileElement,
+                        currentHunk.oldStart,
+                        currentHunk.oldLines,
+                        currentHunk.newStart,
+                        currentHunk.newLines,
+                        currentHunk.header,
+                        preview,
+                        firstLine,
+                        currentHunk.lines
+                    ));
+                }
+                
+                // Commencer un nouveau hunk
+                const oldStart = parseInt(match[1]);
+                const oldLines = match[2] ? parseInt(match[2]) : 1;
+                const newStart = parseInt(match[3]);
+                const newLines = match[4] ? parseInt(match[4]) : 1;
+                const header = match[5].trim();
+                
+                currentHunk = {
+                    oldStart,
+                    oldLines,
+                    newStart,
+                    newLines,
+                    header,
+                    lines: []
+                };
+            } else if (currentHunk && (line.startsWith('+') || line.startsWith('-') || line.startsWith(' '))) {
+                // Collecter les lignes du hunk
+                currentHunk.lines.push(line);
+            }
+        }
+        
+        // Ajouter le dernier hunk
+        if (currentHunk) {
+            const preview = currentHunk.lines.slice(0, 3).join('\n');
+            // Trouver la première ligne avec + ou -
+            const firstAddedLine = currentHunk.lines.find(l => l.startsWith('+') && !l.startsWith('+++'));
+            const firstRemovedLine = currentHunk.lines.find(l => l.startsWith('-') && !l.startsWith('---'));
+            let firstLine = '';
+            if (firstAddedLine) {
+                firstLine = firstAddedLine.substring(1).trim();
+            } else if (firstRemovedLine) {
+                firstLine = ' - ' + firstRemovedLine.substring(1).trim();
+            }
+            hunks.push(new DiffHunkElement(
+                fileElement,
+                currentHunk.oldStart,
+                currentHunk.oldLines,
+                currentHunk.newStart,
+                currentHunk.newLines,
+                currentHunk.header,
+                preview,
+                firstLine,
+                currentHunk.lines
+            ));
+        }
+        
+        return hunks;
     }
 
     private async updateRefs(baseRef?: string): Promise<void>
@@ -994,6 +1347,27 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
             return;
         }
         await this.doOpenChanges(diffStatus.srcAbsPath, diffStatus.dstAbsPath, diffStatus.status);
+    }
+
+    async openChangesAtLine(hunkElement: DiffHunkElement) {
+        const fileElement = hunkElement.fileElement;
+        await this.doOpenChanges(fileElement.srcAbsPath, fileElement.dstAbsPath, fileElement.status);
+        
+        // Attendre un peu que l'éditeur s'ouvre
+        await new Promise(resolve => setTimeout(resolve, 100));
+        
+        // Naviguer vers la ligne dans l'éditeur actif
+        const editor = window.activeTextEditor;
+        if (editor) {
+            const line = hunkElement.newStart - 1; // Les lignes sont 0-indexées dans l'API
+            const position = new (await import('vscode')).Position(line, 0);
+            const range = new (await import('vscode')).Range(position, position);
+            const selection = new (await import('vscode')).Selection(position, position);
+            const TextEditorRevealType = (await import('vscode')).TextEditorRevealType;
+            
+            editor.selection = selection;
+            editor.revealRange(range, TextEditorRevealType.InCenter);
+        }
     }
 
     async doOpenChanges(srcAbsPath: string, dstAbsPath: string, status: StatusCode, preview=true) {
@@ -1594,7 +1968,7 @@ function toTreeItem(element: Element, openChangesOnSelect: boolean, iconsMinimal
                     asAbsolutePath: (relPath: string) => string): TreeItem {
     const gitIconRoot = asAbsolutePath('resources/git-icons');
     if (element instanceof FileElement) {
-        const item = new TreeItem(element.label);
+        const item = new TreeItem(element.label, TreeItemCollapsibleState.Collapsed);
         const statusText = getStatusText(element);
         item.tooltip = `${element.dstAbsPath} • ${statusText}`;
         if (element.srcAbsPath !== element.dstAbsPath) {
@@ -1620,6 +1994,23 @@ function toTreeItem(element: Element, openChangesOnSelect: boolean, iconsMinimal
                 title: ''
             };
         }
+        return item;
+    } else if (element instanceof DiffHunkElement) {
+        const item = new TreeItem(element.firstLine || element.header || element.label);
+        item.description = `Lines ${element.newStart}-${element.newStart + element.newLines - 1}`;
+        item.tooltip = element.preview;
+        item.contextValue = 'diffHunk';
+        item.id = `${element.fileElement.dstAbsPath}:${element.newStart}`;
+        item.iconPath = new ThemeIcon('diff');
+        if (checkboxState !== undefined) {
+            item.checkboxState = checkboxState;
+        }
+        // Commande pour ouvrir le diff à la ligne spécifique
+        item.command = {
+            command: NAMESPACE + '.openChangesAtLine',
+            arguments: [element],
+            title: ''
+        };
         return item;
     } else if (element instanceof RepoRootElement) {
         const item = new TreeItem(element.label, TreeItemCollapsibleState.Collapsed);

--- a/src/treeProvider.ts
+++ b/src/treeProvider.ts
@@ -62,7 +62,7 @@ class DiffHunkElement {
         public status: 'A' | 'M' | 'D') {}
 
     get label(): string {
-        return this.preview || `Line ${this.newStart}`;
+        return this.preview;
     }
 }
 
@@ -464,7 +464,7 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
 
             await fs.promises.mkdir(path.dirname(storagePath), { recursive: true });
             await fs.promises.writeFile(storagePath, JSON.stringify(data, null, 2), 'utf-8');
-            this.log(`Saved ${added ? 'added' : 'removed'} ${elements.length} hunks to ${storagePath}`);
+            this.log(`Saved ${added ? '+' : '-'}${elements.length} hunks to ${storagePath}`);
         } catch (error) {
             this.log('Failed to save checked hunks', error as Error);
         }
@@ -892,23 +892,27 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
                     let startOfLine = gitDiff.indexOf('\n', match!.index) + 1;
                     let inHunk = true;
 
-                    function saveHunkCompleted(h: HunkContext) {
-                        if(h.end + DiffHunkElement.HUNK_CONTEXT_LINES === line) {
-                            for(let i=0; i<DiffHunkElement.HUNK_CONTEXT_LINES; i++) {
-                                const ctxLine = ctxLines[(ctxLinesIdx + i) % DiffHunkElement.HUNK_CONTEXT_LINES];
-                                if(ctxLine) {
-                                    h.hash.update(gitDiff.substring(ctxLine[0], ctxLine[1]));
-                                }
+                    function saveHunk(h: HunkContext) {
+                        const ctxNb = line - h.end;
+                        for(let i=DiffHunkElement.HUNK_CONTEXT_LINES - ctxNb; i<DiffHunkElement.HUNK_CONTEXT_LINES; i++) {
+                            const ctxLine = ctxLines[(ctxLinesIdx + i) % DiffHunkElement.HUNK_CONTEXT_LINES];
+                            if(ctxLine) {
+                                h.hash.update(gitDiff.substring(ctxLine[0], ctxLine[1]));
                             }
-                            const status2char:['M', 'D', 'A', 'M'] = ['M', 'D', 'A', 'M'];
-                            const hunkElement = new DiffHunkElement(
-                                currentFile,
-                                h.line + 1,
-                                h.preview.substring(1),
-                                h.hash.digest('hex').substring(0, 16),
-                                status2char[h.status]
-                            );
-                            hunksMap.get(currentFile.dstAbsPath)?.push(hunkElement);
+                        }
+                        const status2char:['M', 'D', 'A', 'M'] = ['M', 'D', 'A', 'M'];
+                        const hunkElement = new DiffHunkElement(
+                            currentFile,
+                            h.line + 1,
+                            h.preview.substring(1),
+                            h.hash.digest('hex').substring(0, 16),
+                            status2char[h.status]
+                        );
+                        hunksMap.get(currentFile.dstAbsPath)?.push(hunkElement);
+                    }
+                    function saveHunkIfComplete(h: HunkContext) {
+                        if(h.end + DiffHunkElement.HUNK_CONTEXT_LINES === line) {
+                            saveHunk(h);
                             return false;
                         }
                         return true;
@@ -953,8 +957,9 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
                             case '@':
                                 if(currentHunk) {
                                     currentHunk.end = line;
-                                    saveHunkCompleted(currentHunk);
+                                    saveHunk(currentHunk);
                                 }
+                                closingHunk.forEach(saveHunk);
                                 gitDiff = gitDiff.substring(startOfLine);
                                 match = gitDiff.match(/@@ -\d+(,\d+)? \+(\d+)(,\d+)? @@/);
                                 ctxLines = [];
@@ -967,8 +972,9 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
                             default:
                                 if(currentHunk) {
                                     currentHunk.end = line;
-                                    saveHunkCompleted(currentHunk);
+                                    saveHunk(currentHunk);
                                 }
+                                closingHunk.forEach(saveHunk);
                                 inHunk = false;
                                 continue; // end of hunks for this file
                         }
@@ -976,7 +982,7 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
                             ctxLines[ctxLinesIdx] = [startOfLine + 1, endOfLine];
                             ctxLinesIdx = (ctxLinesIdx + 1) % DiffHunkElement.HUNK_CONTEXT_LINES
                             line++;
-                            closingHunk = closingHunk.filter(saveHunkCompleted);
+                            closingHunk = closingHunk.filter(saveHunkIfComplete);
                         }
                         startOfLine = endOfLine;
                     }
@@ -1008,7 +1014,8 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
             }
             
             this.hunksMap = hunksMap;
-            this.log(`Loaded ${hunksMap.size} files with hunks`);
+            const totalHunks = Array.from(hunksMap.values()).reduce((sum, hunks) => sum + hunks.length, 0);
+            this.log(`Loaded ${totalHunks} hunks in ${hunksMap.size} files`);
         }
 
         // Always refresh when sorting by recently modified in list view, as file mtimes may have changed

--- a/src/treeProvider.ts
+++ b/src/treeProvider.ts
@@ -144,6 +144,7 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
     private showCollapsed: boolean;
     private compactFolders: boolean;
     private showCheckboxes: boolean;
+    private showDiffDetails: boolean;
     private resetCheckboxOnFileChange: boolean;
     private omitUntrackedFiles: boolean;
     private omitUnstagedChanges: boolean;
@@ -396,7 +397,7 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
         }
         try {
             const repoName = path.basename(this.repository.root);
-            const storagePath = path.join(this.storageUri.fsPath, `checked-hunks-${repoName}.diff`);
+            const storagePath = path.join(this.storageUri.fsPath, `checked-hunks-${repoName}-${this.headCommit}-${this.mergeBase}.diff`);
             
             if (!fs.existsSync(storagePath)) {
                 return false;
@@ -437,7 +438,7 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
         }
         try {
             const repoName = path.basename(this.repository.root);
-            const storagePath = path.join(this.storageUri.fsPath, `checked-hunks-${repoName}.diff`);
+            const storagePath = path.join(this.storageUri.fsPath, `checked-hunks-${repoName}-${this.headCommit}-${this.mergeBase}.diff`);
             
             // Structure pour stocker les hunks par fichier avec leur contenu complet
             const fileHunks = new Map<string, Array<{oldStart: number, oldLines: number, newStart: number, newLines: number, header: string, lines: string[]}>>();
@@ -587,6 +588,7 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
         this.showCollapsed = config.get<boolean>('collapsed', false);
         this.compactFolders = config.get<boolean>('compactFolders', false);
         this.showCheckboxes = config.get<boolean>('showCheckboxes', false);
+        this.showDiffDetails = config.get<boolean>('showDiffDetails', true);
         this.resetCheckboxOnFileChange = config.get<boolean>('resetCheckboxOnFileChange', false);
         this.omitUntrackedFiles = config.get<boolean>('omitUntrackedFiles', false);
         this.omitUnstagedChanges = config.get<boolean>('omitUnstagedChanges', false);
@@ -638,7 +640,7 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
                 checkboxState = this.isHunkChecked(element) ? TreeItemCheckboxState.Checked : TreeItemCheckboxState.Unchecked;
             }
         }
-        return toTreeItem(element, this.openChangesOnSelect, this.iconsMinimal, this.showCollapsed, this.viewAsList, checkboxState, this.asAbsolutePath);
+        return toTreeItem(element, this.openChangesOnSelect, this.iconsMinimal, this.showCollapsed, this.viewAsList, checkboxState, this.showDiffDetails, this.asAbsolutePath);
     }
 
     private async computeFileCheckboxState(file: FileElement): Promise<TreeItemCheckboxState> {
@@ -1141,6 +1143,7 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
         const oldRenameThreshold = this.renameThreshold;
         const oldCompactFolders = this.compactFolders;
         const oldshowCheckboxes = this.showCheckboxes;
+        const oldShowDiffDetails = this.showDiffDetails;
         const oldOmitUntrackedFiles = this.omitUntrackedFiles;
         const oldOmitUnstagedChanges = this.omitUnstagedChanges;
         const oldSortOrder = this.sortOrder;
@@ -1156,6 +1159,7 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
             oldRenameThreshold != this.renameThreshold ||
             oldCompactFolders != this.compactFolders ||
             oldshowCheckboxes != this.showCheckboxes ||
+            oldShowDiffDetails != this.showDiffDetails ||
             oldOmitUntrackedFiles != this.omitUntrackedFiles ||
             oldOmitUnstagedChanges != this.omitUnstagedChanges ||
             oldSortOrder != this.sortOrder) {
@@ -1848,6 +1852,11 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
         await config.update('showCheckboxes', !v, true);
     }
 
+    async hideDiffDetails(v: boolean) {
+        const config = workspace.getConfiguration(NAMESPACE);
+        await config.update('showDiffDetails', !v, true);
+    }
+
     viewAsTree(v: boolean) {
         const viewAsList = !v;
         if (viewAsList === this.viewAsList)
@@ -1965,10 +1974,11 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
 function toTreeItem(element: Element, openChangesOnSelect: boolean, iconsMinimal: boolean,
                     showCollapsed: boolean, viewAsList: boolean,
                     checkboxState: TreeItemCheckboxState | undefined,
+                    showDiffDetails: boolean,
                     asAbsolutePath: (relPath: string) => string): TreeItem {
     const gitIconRoot = asAbsolutePath('resources/git-icons');
     if (element instanceof FileElement) {
-        const item = new TreeItem(element.label, TreeItemCollapsibleState.Collapsed);
+        const item = new TreeItem(element.label, showDiffDetails ? TreeItemCollapsibleState.Collapsed : TreeItemCollapsibleState.None);
         const statusText = getStatusText(element);
         item.tooltip = `${element.dstAbsPath} • ${statusText}`;
         if (element.srcAbsPath !== element.dstAbsPath) {

--- a/src/treeProvider.ts
+++ b/src/treeProvider.ts
@@ -381,7 +381,7 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
         }
         try {
             const repoName = path.basename(this.repository.root);
-            const storagePath = path.join(this.storageUri.fsPath, `checked-hunks-${repoName}-${this.headCommit}-${this.mergeBase}.diff`);
+            const storagePath = path.join(this.storageUri.fsPath, `checked-hunks-${repoName}-${this.mergeBase}.diff`);
             
             if (!fs.existsSync(storagePath)) {
                 return false;
@@ -422,7 +422,7 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
         }
         try {
             const repoName = path.basename(this.repository.root);
-            const storagePath = path.join(this.storageUri.fsPath, `checked-hunks-${repoName}-${this.headCommit}-${this.mergeBase}.diff`);
+            const storagePath = path.join(this.storageUri.fsPath, `checked-hunks-${repoName}-${this.mergeBase}.diff`);
             
             // Structure pour stocker les hunks par fichier avec leur contenu complet
             const fileHunks = new Map<string, Array<{oldStart: number, oldLines: number, newStart: number, newLines: number, header: string, lines: string[]}>>();

--- a/src/treeProvider.ts
+++ b/src/treeProvider.ts
@@ -896,7 +896,9 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
                         if(h.end + DiffHunkElement.HUNK_CONTEXT_LINES === line) {
                             for(let i=0; i<DiffHunkElement.HUNK_CONTEXT_LINES; i++) {
                                 const ctxLine = ctxLines[(ctxLinesIdx + i) % DiffHunkElement.HUNK_CONTEXT_LINES];
-                                h.hash.update(gitDiff.substring(ctxLine[0], ctxLine[1]));
+                                if(ctxLine) {
+                                    h.hash.update(gitDiff.substring(ctxLine[0], ctxLine[1]));
+                                }
                             }
                             const status2char:['M', 'D', 'A', 'M'] = ['M', 'D', 'A', 'M'];
                             const hunkElement = new DiffHunkElement(
@@ -937,7 +939,9 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
                                     };
                                     for(let i=0; i<DiffHunkElement.HUNK_CONTEXT_LINES; i++) {
                                         const ctxLine = ctxLines[(ctxLinesIdx + i) % DiffHunkElement.HUNK_CONTEXT_LINES];
-                                        currentHunk.hash.update(gitDiff.substring(ctxLine[0], ctxLine[1]));
+                                        if(ctxLine) {
+                                            currentHunk.hash.update(gitDiff.substring(ctxLine[0], ctxLine[1]));
+                                        }
                                     }
                                 }
                                 if(mostRecent && (currentHunk.preview[0] === '-' || currentHunk.preview === '+')) {

--- a/src/treeProvider.ts
+++ b/src/treeProvider.ts
@@ -929,7 +929,7 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
                                         currentHunk.hash.update(gitDiff.substring(ctxLine[0], ctxLine[1]));
                                     }
                                 }
-                                if(mostRecent && (currentHunk.preview[0] === '-') || currentHunk.preview === '+') {
+                                if(mostRecent && (currentHunk.preview[0] === '-' || currentHunk.preview === '+')) {
                                     currentHunk.preview = gitDiff.substring(startOfLine, endOfLine-1);
                                 }
                                 currentHunk.status |= mostRecent ? 2 : 1;
@@ -970,7 +970,6 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
             } catch (e) {
                 this.log('Failed to retrieve diff hunks', e as Error);
             }
-            console.log('hunksMap', hunksMap.size, hunksMap);
 
             if (!this.hunksMap || this.hunksMap.size !== hunksMap.size) {
                 hunksHaveChanged = true;

--- a/src/treeProvider.ts
+++ b/src/treeProvider.ts
@@ -1,8 +1,8 @@
 import * as assert from 'assert'
 import * as path from 'path'
 import * as fs from 'fs'
-import * as crypto from 'crypto'
 
+import { Hash, createHash } from 'crypto'
 import { TreeDataProvider, TreeItem, TreeItemCollapsibleState,
          Uri, Disposable, EventEmitter, TextDocumentShowOptions,
          QuickPickItem, ProgressLocation, Memento, OutputChannel, Range,
@@ -31,6 +31,11 @@ const STATUS_SORT_ORDER: { [key: string]: number } = {
     'U': 5, // Untracked
     'T': 6  // Type change
 };
+
+interface CheckboxStateInfo {
+    state: TreeItemCheckboxState;
+    timestamp: number; // When the checkbox was checked
+}
 
 class FileElement implements IDiffStatus {
     modificationDate?: Date;
@@ -135,6 +140,7 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
     private showCollapsed: boolean;
     private compactFolders: boolean;
     private showCheckboxes: boolean;
+    private resetCheckboxOnFileChange: boolean;
     private showDiffDetails: boolean;
     private omitUntrackedFiles: boolean;
     private omitUnstagedChanges: boolean;
@@ -169,6 +175,7 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
     // UI state
     private treeView: TreeView<Element>;
     private isPaused: boolean;
+    private checkboxStates: Map<string, CheckboxStateInfo> = new Map<string, CheckboxStateInfo>();
 
     // Other
     private readonly disposables: Disposable[] = [];
@@ -273,6 +280,7 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
             window.showErrorMessage(`${msg}: ${e.message}`);
             return;
         }
+        this.checkboxStates.clear();
         this._onDidChangeTreeData.fire();
     }
 
@@ -339,18 +347,30 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
     }
 
     private async handleChangeCheckboxState(e: TreeCheckboxChangeEvent<Element>) {
+        if(!this.showDiffDetails) {
+            for (let [element, state] of e.items) {
+                if (element instanceof FileElement || element instanceof FolderElement) {
+                    this.checkboxStates.set(element.dstAbsPath, {
+                        state: state,
+                        timestamp: Date.now()
+                    });
+                }
+            }
+            return;
+        }
         const diff: DiffHunkElement[][] = [[],[]];
         for (const [element, state] of e.items) {
             if (element instanceof FileElement) {
                 const childHunkPresent = e.items.some(([nextElement, _]) => nextElement instanceof DiffHunkElement && nextElement.fileElement.dstAbsPath === element.dstAbsPath);
                 if (!childHunkPresent) {
-                    // process only if hunk of these files are not already included in event
+                    // process only if no hunk from this file are included in event
                     const hunks = await this.getDiffHunks(element.dstAbsPath);
                     diff[state].push(...hunks);
                 }
             } else if (element instanceof FolderElement) {
                 const childFilePresent = e.items.some(([nextElement, _]) => nextElement instanceof FileElement && nextElement.dstAbsPath.includes(element.dstAbsPath));
                 if (!childFilePresent) {
+                    // process only if no file from this folder are included in event
                     const files = element.useFilesOutsideTreeRoot ? this.filesOutsideTreeRoot : this.filesInsideTreeRoot;
                     for (const [folderPath, fileEntries] of files.entries()) {
                         if (folderPath === element.dstAbsPath || folderPath.startsWith(element.dstAbsPath + path.sep)) {
@@ -377,14 +397,13 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
         try {
             const repoName = path.basename(this.repository.root);
             const storagePath = path.join(this.storageUri.fsPath, `checked-hunks-${repoName}-${this.mergeBase}.json`);
-            
+
             if (!fs.existsSync(storagePath)) {
                 return false;
             }
-            
-            const content = fs.readFileSync(storagePath, 'utf-8');
-            const data = JSON.parse(content);
-            
+
+            const data = JSON.parse(fs.readFileSync(storagePath, 'utf-8'));
+
             const targetFile = element.fileElement.dstAbsPath;
             const targetHash = element.hash;
             
@@ -472,6 +491,7 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
         this.showCollapsed = config.get<boolean>('collapsed', false);
         this.compactFolders = config.get<boolean>('compactFolders', false);
         this.showCheckboxes = config.get<boolean>('showCheckboxes', false);
+        this.resetCheckboxOnFileChange = config.get<boolean>('resetCheckboxOnFileChange', false);
         this.showDiffDetails = config.get<boolean>('showDiffDetails', true);
         this.omitUntrackedFiles = config.get<boolean>('omitUntrackedFiles', false);
         this.omitUnstagedChanges = config.get<boolean>('omitUnstagedChanges', false);
@@ -527,6 +547,10 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
     }
 
     private async computeFileCheckboxState(dstAbsPath: string): Promise<TreeItemCheckboxState> {
+        if(!this.showDiffDetails) {
+            const stateInfo = this.checkboxStates.get(dstAbsPath);
+            return stateInfo?.state ?? TreeItemCheckboxState.Unchecked;
+        }
         let hasHunks = false;
         const hunks = await this.getDiffHunks(dstAbsPath);
         for (const hunkElement of hunks) {
@@ -539,7 +563,14 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
     }
 
     private async computeFolderCheckboxState(folder: FolderElement): Promise<TreeItemCheckboxState> {
-        // Derive from files: folder is checked only if ALL files under it are checked
+        if(!this.showDiffDetails) {
+            // Check if user explicitly set state on this folder
+            const explicitState = this.checkboxStates.get(folder.dstAbsPath);
+            if (explicitState) {
+                return explicitState.state;
+            }
+        }
+        // Otherwise derive from files: folder is checked only if ALL files under it are checked
         const files = folder.useFilesOutsideTreeRoot ? this.filesOutsideTreeRoot : this.filesInsideTreeRoot;
         let hasFiles = false;
         
@@ -654,6 +685,7 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
             }
             if (this.headName !== headName) {
                 this.log(`HEAD ref updated: ${this.headName} -> ${headName}`);
+                this.checkboxStates.clear();
             }
             if (this.headCommit !== headCommit) {
                 this.log(`HEAD ref commit updated: ${this.headCommit} -> ${headCommit}`);
@@ -689,6 +721,8 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
         this.log(`${diff.length} diff entries (${untrackedCount} untracked)`);
 
         const newFilePaths = new Set<string>();
+        // Collect files that need mtime checking for async batch processing
+        const filesToCheckMtime: Array<{filePath: string, stateInfo: CheckboxStateInfo}> = [];
         
         for (const entry of diff) {
             const folder = path.dirname(entry.dstAbsPath);
@@ -715,6 +749,54 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
 
             // Track new file paths
             newFilePaths.add(entry.dstAbsPath);
+            
+            // Collect checked files for mtime checking to reset if modified after being checked
+            if (this.resetCheckboxOnFileChange) {
+                const stateInfo = this.checkboxStates.get(entry.dstAbsPath);
+                if (stateInfo && stateInfo.state === TreeItemCheckboxState.Checked) {
+                    filesToCheckMtime.push({filePath: entry.dstAbsPath, stateInfo});
+                }
+            }
+        }
+
+        // Check file modification times asynchronously in parallel
+        if (this.resetCheckboxOnFileChange && filesToCheckMtime.length > 0) {
+            const statPromises = filesToCheckMtime.map(async ({filePath, stateInfo}) => {
+                try {
+                    const stats = await fs.promises.stat(filePath);
+                    const fileMtime = stats.mtimeMs;
+                    
+                    // If file was modified after checkbox was checked, reset it
+                    if (fileMtime > stateInfo.timestamp) {
+                        return filePath;
+                    }
+                } catch (error: unknown) {
+                    // File might be deleted or inaccessible - this is expected in some cases
+                    const errorMessage = error instanceof Error ? error.message : String(error);
+                    this.log(`Could not stat file for checkbox reset check: ${filePath}: ${errorMessage}`);
+                }
+                return null;
+            });
+            
+            const pathsToReset = await Promise.all(statPromises);
+            const actualPathsToReset = pathsToReset.filter((filePath): filePath is string => filePath !== null);
+            actualPathsToReset.forEach(filePath => this.checkboxStates.delete(filePath));
+            
+            // Fire tree refresh to update checkbox UI
+            if (actualPathsToReset.length > 0) {
+                this._onDidChangeTreeData.fire();
+            }
+        }
+
+        // Clear checkbox state for files that no longer exist in the diff
+        const pathsToDelete: string[] = [];
+        for (const [filePath] of this.checkboxStates) {
+            if (!newFilePaths.has(filePath)) {
+                pathsToDelete.push(filePath);
+            }
+        }
+        for (const filePath of pathsToDelete) {
+            this.checkboxStates.delete(filePath);
         }
 
         let treeHasChanged = false;
@@ -767,7 +849,7 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
         if(this.showDiffDetails) {
             const hunksMap = new Map<string, DiffHunkElement[]>();
             try {
-                type HunkContext = {line:number, end:number, hash:crypto.Hash, preview:string, status:number};
+                type HunkContext = {line:number, end:number, hash:Hash, preview:string, status:number};
 
                 let gitDiff = (await this.repository!.exec(['diff', `-U${DiffHunkElement.HUNK_CONTEXT_LINES}`, '-w', this.mergeBase])).stdout;
 
@@ -838,7 +920,7 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
                                     currentHunk = {
                                         line,
                                         end: line,
-                                        hash: crypto.createHash('sha1'),
+                                        hash: createHash('sha1'),
                                         preview: gitDiff.substring(startOfLine, endOfLine-1),
                                         status: mostRecent ? 2 : 1,
                                     };


### PR DESCRIPTION
Thank you for this extension it makes review really easy and nice to stop and start again. I wanted to increase the granularity level by allowing to check each hunk individually so when for example the branch is updated it's easy to track new modifications. This feature works by running `git diff` in `updateDiff` (only if the feature is enabled, ie: hunks are shown).

---

This pull request introduces a new feature to the Git Tree Compare extension that allows users to view and manage diff hunks (individual change blocks) within files, and to check off specific hunks as reviewed. It adds new commands and configuration options for showing/hiding diff details, updates the UI to support hunk-level operations, and persists checked hunks per repository. The changes also refactor checkbox logic to work at both file and hunk granularity.

**New Feature: Diff Hunk Details and Hunk-Level Checkboxes**
- Added commands and context menu entries for showing/hiding diff details (hunks) in the UI, letting users expand files to see and interact with individual change hunks. (`package.json`, `src/extension.ts`) [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R139-R148) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L289-R324) [[3]](diffhunk://#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626R91-R96)
- Introduced a new configuration option `gitTreeCompare.showDiffDetails` to enable or disable diff hunk display, defaulting to enabled. (`package.json`, `src/treeProvider.ts`) [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R554-R558) [[2]](diffhunk://#diff-3800b1487f3cba557cc8bdd8a89ab4b57ba23012c94078cfddbe48a3b287c17eR495)

**UI and Checkbox Logic Updates**
- Updated the tree provider to support a new `DiffHunkElement` type, so each file can have child hunk elements when diff details are shown. (`src/treeProvider.ts`) [[1]](diffhunk://#diff-3800b1487f3cba557cc8bdd8a89ab4b57ba23012c94078cfddbe48a3b287c17eR55-R68) [[2]](diffhunk://#diff-3800b1487f3cba557cc8bdd8a89ab4b57ba23012c94078cfddbe48a3b287c17eL71-R86)
- Refactored checkbox handling logic: when diff details are enabled, checkboxes appear for each hunk, and checking a file means all its hunks are checked. Folder and file checkbox states are now computed based on the states of their hunks. (`src/treeProvider.ts`) [[1]](diffhunk://#diff-3800b1487f3cba557cc8bdd8a89ab4b57ba23012c94078cfddbe48a3b287c17eR350) [[2]](diffhunk://#diff-3800b1487f3cba557cc8bdd8a89ab4b57ba23012c94078cfddbe48a3b287c17eR359-R459) [[3]](diffhunk://#diff-3800b1487f3cba557cc8bdd8a89ab4b57ba23012c94078cfddbe48a3b287c17eL413-R590)

**Persistence and Storage**
- Added logic to persist checked hunks per repository and merge base, storing the checked state in a JSON file under the extension's storage directory, and reading it to restore state. (`src/treeProvider.ts`, `src/extension.ts`) [[1]](diffhunk://#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626L131-R138) [[2]](diffhunk://#diff-3800b1487f3cba557cc8bdd8a89ab4b57ba23012c94078cfddbe48a3b287c17eR170) [[3]](diffhunk://#diff-3800b1487f3cba557cc8bdd8a89ab4b57ba23012c94078cfddbe48a3b287c17eL167-R184) [[4]](diffhunk://#diff-3800b1487f3cba557cc8bdd8a89ab4b57ba23012c94078cfddbe48a3b287c17eR359-R459)

**Command and API Enhancements**
- Registered new commands for toggling diff detail visibility and updated the provider to accept a storage URI for saving hunk state. (`src/extension.ts`, `src/treeProvider.ts`) [[1]](diffhunk://#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626R91-R96) [[2]](diffhunk://#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626L131-R138) [[3]](diffhunk://#diff-3800b1487f3cba557cc8bdd8a89ab4b57ba23012c94078cfddbe48a3b287c17eL167-R184)

These changes make it possible to review and track progress at a much finer granularity, which is particularly useful for large or complex diffs.

**Preview**
<img title="Tree view with hunks & checkboxes" width="303" height="532" alt="image" src="https://github.com/user-attachments/assets/51978863-4a47-463b-9520-663105c2f64b" />  <img title="List view with hunks" width="303" height="422" alt="image" src="https://github.com/user-attachments/assets/32dbcd96-9999-456e-9fae-050ab858807d" />