### PR TITLE
Add multi-repository tree view

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,3 +83,5 @@ This feature works with both PRs from the same repository and PRs from forks.
 `gitTreeCompare.openChangesWithDifftool` When enabled, adds an "Open Changes with Difftool" command to the context menu for files. This command opens the changes in the external diff tool configured in Git (e.g., via `git config diff.tool <tool-name>`). Default is disabled. Note: This requires you to have a difftool configured in your Git settings.
 
 `gitTreeCompare.showDiffStats` When enabled, shows insertion/deletion counts (+N -N) next to each file name in the tree view. Default is disabled.
+
+`gitTreeCompare.multiRepositoryView` [EXPERIMENTAL] When enabled and the workspace contains more than one Git repository, the tree shows one expanded section per repository instead of comparing a single active repository. Each repository keeps its own comparison base, filter and checkbox state. Workspaces with a single repository are unaffected. Default is disabled.

--- a/package.json
+++ b/package.json
@@ -251,38 +251,48 @@
       ],
       "view/title": [
         {
+          "command": "gitTreeCompare.changeRepository",
+          "when": "view == gitTreeCompare && !config.gitTreeCompare.multiRepositoryView && gitOpenRepositoryCount != 1",
+          "group": "1_state"
+        },
+        {
+          "command": "gitTreeCompare.changeRepository",
+          "when": "view == gitTreeCompare && !config.gitTreeCompare.multiRepositoryView && gitOpenRepositoryCount != 1",
+          "group": "navigation@2"
+        },
+        {
           "command": "gitTreeCompare.changeBase",
-          "when": "view == gitTreeCompare && gitOpenRepositoryCount == 1",
+          "when": "view == gitTreeCompare && (!config.gitTreeCompare.multiRepositoryView || gitOpenRepositoryCount == 1)",
           "group": "1_state"
         },
         {
           "command": "gitTreeCompare.compareGitHubPullRequest",
-          "when": "view == gitTreeCompare && gitOpenRepositoryCount == 1",
+          "when": "view == gitTreeCompare && (!config.gitTreeCompare.multiRepositoryView || gitOpenRepositoryCount == 1)",
           "group": "1_state"
         },
         {
           "command": "gitTreeCompare.openAllChanges",
-          "when": "view == gitTreeCompare && gitOpenRepositoryCount == 1",
+          "when": "view == gitTreeCompare && (!config.gitTreeCompare.multiRepositoryView || gitOpenRepositoryCount == 1)",
           "group": "2_files"
         },
         {
           "command": "gitTreeCompare.openChangedFiles",
-          "when": "view == gitTreeCompare && gitOpenRepositoryCount == 1",
+          "when": "view == gitTreeCompare && (!config.gitTreeCompare.multiRepositoryView || gitOpenRepositoryCount == 1)",
           "group": "2_files"
         },
         {
           "command": "gitTreeCompare.discardAllChanges",
-          "when": "view == gitTreeCompare && gitOpenRepositoryCount == 1",
+          "when": "view == gitTreeCompare && (!config.gitTreeCompare.multiRepositoryView || gitOpenRepositoryCount == 1)",
           "group": "2_files"
         },
         {
           "command": "gitTreeCompare.refresh",
-          "when": "view == gitTreeCompare && gitOpenRepositoryCount == 1",
+          "when": "view == gitTreeCompare",
           "group": "1_state"
         },
         {
           "command": "gitTreeCompare.refresh",
-          "when": "view == gitTreeCompare && gitOpenRepositoryCount == 1",
+          "when": "view == gitTreeCompare",
           "group": "navigation@3"
         },
         {
@@ -317,17 +327,17 @@
         },
         {
           "command": "gitTreeCompare.searchChanges",
-          "when": "view == gitTreeCompare && gitOpenRepositoryCount == 1",
+          "when": "view == gitTreeCompare && (!config.gitTreeCompare.multiRepositoryView || gitOpenRepositoryCount == 1)",
           "group": "2_files"
         },
         {
           "command": "gitTreeCompare.filterFiles",
-          "when": "view == gitTreeCompare && gitOpenRepositoryCount == 1",
+          "when": "view == gitTreeCompare && (!config.gitTreeCompare.multiRepositoryView || gitOpenRepositoryCount == 1)",
           "group": "navigation@4"
         },
         {
           "command": "gitTreeCompare.clearFilter",
-          "when": "view == gitTreeCompare && gitOpenRepositoryCount == 1 && gitTreeCompare.isFiltered",
+          "when": "view == gitTreeCompare && (!config.gitTreeCompare.multiRepositoryView || gitOpenRepositoryCount == 1) && gitTreeCompare.isFiltered",
           "group": "navigation@5"
         },
         {
@@ -339,44 +349,44 @@
       "view/item/context": [
         {
           "command": "gitTreeCompare.changeBase",
-          "when": "view == gitTreeCompare && viewItem == repo",
+          "when": "view == gitTreeCompare && viewItem == repo && config.gitTreeCompare.multiRepositoryView",
           "group": "inline@1"
         },
         {
           "command": "gitTreeCompare.openAllChanges",
-          "when": "view == gitTreeCompare && viewItem == repo",
+          "when": "view == gitTreeCompare && viewItem == repo && config.gitTreeCompare.multiRepositoryView",
           "group": "inline@2"
         },
         {
           "command": "gitTreeCompare.openChangedFiles",
-          "when": "view == gitTreeCompare && viewItem == repo",
+          "when": "view == gitTreeCompare && viewItem == repo && config.gitTreeCompare.multiRepositoryView",
           "group": "inline@3"
         },
         {
           "command": "gitTreeCompare.refresh",
-          "when": "view == gitTreeCompare && viewItem == repo",
+          "when": "view == gitTreeCompare && viewItem == repo && config.gitTreeCompare.multiRepositoryView",
           "group": "inline@4"
         },
         {
           "command": "gitTreeCompare.filterFiles",
-          "when": "view == gitTreeCompare && viewItem == repo",
+          "when": "view == gitTreeCompare && viewItem == repo && config.gitTreeCompare.multiRepositoryView",
           "group": "inline@5"
         },
         {
           "command": "gitTreeCompare.discardAllChanges",
-          "when": "view == gitTreeCompare && viewItem == repo"
+          "when": "view == gitTreeCompare && viewItem == repo && config.gitTreeCompare.multiRepositoryView"
         },
         {
           "command": "gitTreeCompare.compareGitHubPullRequest",
-          "when": "view == gitTreeCompare && viewItem == repo"
+          "when": "view == gitTreeCompare && viewItem == repo && config.gitTreeCompare.multiRepositoryView"
         },
         {
           "command": "gitTreeCompare.searchChanges",
-          "when": "view == gitTreeCompare && viewItem == repo"
+          "when": "view == gitTreeCompare && viewItem == repo && config.gitTreeCompare.multiRepositoryView"
         },
         {
           "command": "gitTreeCompare.clearFilter",
-          "when": "view == gitTreeCompare && viewItem == repo && gitTreeCompare.isFiltered"
+          "when": "view == gitTreeCompare && viewItem == repo && config.gitTreeCompare.multiRepositoryView && gitTreeCompare.isFiltered"
         },
         {
           "command": "gitTreeCompare.openChanges",
@@ -492,7 +502,7 @@
         },
         {
           "submenu": "gitTreeCompare.viewAndSort",
-          "when": "view == gitTreeCompare && (viewItem == ref || viewItem == repo)",
+          "when": "view == gitTreeCompare && (viewItem == ref || (viewItem == repo && config.gitTreeCompare.multiRepositoryView))",
           "group": "0_view_and_sort"
         },
         {
@@ -508,6 +518,11 @@
         "gitTreeCompare.autoChangeRepository": {
           "type": "boolean",
           "description": "[EXPERIMENTAL] Whether to change the active repository whenever a different one is selected in the SCM view. Note that this only works well when not selecting multiple repositories. See GitHub issue #70 for more details.",
+          "default": false
+        },
+        "gitTreeCompare.multiRepositoryView": {
+          "type": "boolean",
+          "description": "[EXPERIMENTAL] Whether to show one expandable Git Tree Compare section per open repository instead of selecting a single active repository.",
           "default": false
         },
         "gitTreeCompare.autoRefresh": {

--- a/package.json
+++ b/package.json
@@ -112,6 +112,12 @@
       },
       {
         "command": "gitTreeCompare.refresh",
+        "title": "Refresh Repository",
+        "icon": "$(refresh)",
+        "category": "Git Tree Compare"
+      },
+      {
+        "command": "gitTreeCompare.refreshAll",
         "title": "Refresh",
         "icon": "$(refresh)",
         "category": "Git Tree Compare"
@@ -286,12 +292,12 @@
           "group": "2_files"
         },
         {
-          "command": "gitTreeCompare.refresh",
+          "command": "gitTreeCompare.refreshAll",
           "when": "view == gitTreeCompare",
           "group": "1_state"
         },
         {
-          "command": "gitTreeCompare.refresh",
+          "command": "gitTreeCompare.refreshAll",
           "when": "view == gitTreeCompare",
           "group": "navigation@3"
         },

--- a/package.json
+++ b/package.json
@@ -1,631 +1,659 @@
 {
-    "name": "git-tree-compare",
-    "displayName": "Git Tree Compare",
-    "description": "Diff your worktree against a branch, tag, or commit in a tree -- especially useful for pull request preparation or merge preview",
-    "version": "1.20.0",
-    "author": {
-        "name": "Maik Riechert",
-        "url": "https://github.com/letmaik"
-    },
-    "publisher": "letmaik",
-    "license": "MIT",
-    "icon": "resources/logo.png",
-    "categories": [
-        "Other"
-    ],
-    "keywords": [
-        "git",
-        "diff",
-        "tree",
-        "compare",
-        "branch"
-    ],
-    "bugs": {
-        "url": "https://github.com/letmaik/vscode-git-tree-compare/issues"
-    },
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/letmaik/vscode-git-tree-compare.git"
-    },
-    "homepage": "https://github.com/letmaik/vscode-git-tree-compare",
-    "engines": {
-        "vscode": "^1.81.0"
-    },
-    "capabilities": {
-        "virtualWorkspaces": false,
-        "untrustedWorkspaces": {
-            "supported": true
-        }
-    },
-    "extensionDependencies": [
-        "vscode.git"
-    ],
-    "main": "./dist/extension",
-    "contributes": {
-        "viewsContainers": {
-            "activitybar": [
-                {
-                    "id": "gitTreeCompare",
-                    "icon": "./resources/logo.svg",
-                    "title": "Git Tree Compare"
-                }
-            ]
-        },
-        "views": {
-            "gitTreeCompare": [
-                {
-                    "id": "gitTreeCompare",
-                    "name": "none",
-                    "when": "config.git.enabled && gitOpenRepositoryCount != 0",
-                    "icon": "./resources/logo.svg"
-                }
-            ]
-        },
-        "commands": [
-            {
-                "command": "gitTreeCompare.changeRepository",
-                "title": "Change Repository...",
-                "icon": "$(repo)",
-                "category": "Git Tree Compare"
-            },
-            {
-                "command": "gitTreeCompare.openChanges",
-                "title": "Open Changes",
-                "icon": "$(git-compare)",
-                "category": "Git Tree Compare"
-            },
-            {
-                "command": "gitTreeCompare.openFile",
-                "title": "Open File",
-                "icon": "$(go-to-file)",
-                "category": "Git Tree Compare"
-            },
-            {
-                "command": "gitTreeCompare.discardChanges",
-                "title": "Discard Changes",
-                "icon": "$(discard)",
-                "category": "Git Tree Compare"
-            },
-            {
-                "command": "gitTreeCompare.discardAllChanges",
-                "title": "Discard All Changes",
-                "icon": "$(discard)",
-                "category": "Git Tree Compare"
-            },
-            {
-                "command": "gitTreeCompare.openAllChanges",
-                "title": "Open All Changes",
-                "icon": "$(git-compare)",
-                "category": "Git Tree Compare"
-            },
-            {
-                "command": "gitTreeCompare.openChangedFiles",
-                "title": "Open Changed Files",
-                "icon": "$(go-to-file)",
-                "category": "Git Tree Compare"
-            },
-            {
-                "command": "gitTreeCompare.changeBase",
-                "title": "Change Base...",
-                "icon": "$(git-branch)",
-                "category": "Git Tree Compare"
-            },
-            {
-                "command": "gitTreeCompare.refresh",
-                "title": "Refresh",
-                "icon": "$(refresh)",
-                "category": "Git Tree Compare"
-            },
-            {
-                "command": "gitTreeCompare.switchToFullDiff",
-                "title": "Switch to Full Diff",
-                "category": "Git Tree Compare"
-            },
-            {
-                "command": "gitTreeCompare.switchToMergeDiff",
-                "title": "Switch to Merge Diff",
-                "category": "Git Tree Compare"
-            },
-            {
-                "command": "gitTreeCompare.showCheckboxes",
-                "title": "Show checkboxes",
-                "category": "Git Tree Compare"
-            },
-            {
-                "command": "gitTreeCompare.hideCheckboxes",
-                "title": "Hide checkboxes",
-                "category": "Git Tree Compare"
-            },
-            {
-                "command": "gitTreeCompare.viewAsList",
-                "title": "View as List",
-                "icon": "$(list-flat)",
-                "category": "Git Tree Compare"
-            },
-            {
-                "command": "gitTreeCompare.viewAsTree",
-                "title": "View as Tree",
-                "icon": "$(list-tree)",
-                "category": "Git Tree Compare"
-            },
-            {
-                "command": "gitTreeCompare.searchChanges",
-                "title": "Search Changes",
-                "icon": "$(search)",
-                "category": "Git Tree Compare"
-            },
-            {
-                "command": "gitTreeCompare.filterFiles",
-                "title": "Filter Files",
-                "icon": "$(filter)",
-                "category": "Git Tree Compare"
-            },
-            {
-                "command": "gitTreeCompare.clearFilter",
-                "title": "Clear Filter",
-                "icon": "$(clear-all)",
-                "category": "Git Tree Compare"
-            },
-            {
-                "command": "gitTreeCompare.copyPath",
-                "title": "Copy Path",
-                "category": "Git Tree Compare"
-            },
-            {
-                "command": "gitTreeCompare.copyRelativePath",
-                "title": "Copy Relative Path",
-                "category": "Git Tree Compare"
-            },
-            {
-                "command": "gitTreeCompare.compareGitHubPullRequest",
-                "title": "Compare GitHub Pull Request...",
-                "icon": "$(github)",
-                "category": "Git Tree Compare"
-            },
-            {
-                "command": "gitTreeCompare.sortByName",
-                "title": "Sort by Name",
-                "category": "Git Tree Compare",
-                "enablement": "gitTreeCompare.viewAsList"
-            },
-            {
-                "command": "gitTreeCompare.sortByPath",
-                "title": "Sort by Path",
-                "category": "Git Tree Compare",
-                "enablement": "gitTreeCompare.viewAsList"
-            },
-            {
-                "command": "gitTreeCompare.sortByStatus",
-                "title": "Sort by Status",
-                "category": "Git Tree Compare",
-                "enablement": "gitTreeCompare.viewAsList"
-            },
-            {
-                "command": "gitTreeCompare.sortByRecentlyModified",
-                "title": "Sort by Recently Modified",
-                "category": "Git Tree Compare",
-                "enablement": "gitTreeCompare.viewAsList"
-            },
-            {
-                "command": "gitTreeCompare.openChangesWithDifftool",
-                "title": "Open Changes with Difftool",
-                "category": "Git Tree Compare"
-            }
-        ],
-        "submenus": [
-            {
-                "id": "gitTreeCompare.viewAndSort",
-                "label": "View & Sort"
-            }
-        ],
-        "menus": {
-            "gitTreeCompare.viewAndSort": [
-                {
-                    "command": "gitTreeCompare.viewAsList",
-                    "group": "1_view@1"
-                },
-                {
-                    "command": "gitTreeCompare.viewAsTree",
-                    "group": "1_view@2"
-                },
-                {
-                    "command": "gitTreeCompare.sortByName",
-                    "group": "2_sort@1",
-                    "enablement": "gitTreeCompare.viewAsList"
-                },
-                {
-                    "command": "gitTreeCompare.sortByPath",
-                    "group": "2_sort@2",
-                    "enablement": "gitTreeCompare.viewAsList"
-                },
-                {
-                    "command": "gitTreeCompare.sortByStatus",
-                    "group": "2_sort@3",
-                    "enablement": "gitTreeCompare.viewAsList"
-                },
-                {
-                    "command": "gitTreeCompare.sortByRecentlyModified",
-                    "group": "2_sort@4",
-                    "enablement": "gitTreeCompare.viewAsList"
-                }
-            ],
-            "view/title": [
-                {
-                    "command": "gitTreeCompare.changeRepository",
-                    "when": "view == gitTreeCompare && gitOpenRepositoryCount != 1",
-                    "group": "1_state"
-                },
-                {
-                    "command": "gitTreeCompare.changeRepository",
-                    "when": "view == gitTreeCompare && gitOpenRepositoryCount != 1",
-                    "group": "navigation@2"
-                },
-                {
-                    "command": "gitTreeCompare.changeBase",
-                    "when": "view == gitTreeCompare",
-                    "group": "1_state"
-                },
-                {
-                    "command": "gitTreeCompare.compareGitHubPullRequest",
-                    "when": "view == gitTreeCompare",
-                    "group": "1_state"
-                },
-                {
-                    "command": "gitTreeCompare.openAllChanges",
-                    "when": "view == gitTreeCompare",
-                    "group": "2_files"
-                },
-                {
-                    "command": "gitTreeCompare.openChangedFiles",
-                    "when": "view == gitTreeCompare",
-                    "group": "2_files"
-                },
-                {
-                    "command": "gitTreeCompare.discardAllChanges",
-                    "when": "view == gitTreeCompare",
-                    "group": "2_files"
-                },
-                {
-                    "command": "gitTreeCompare.refresh",
-                    "when": "view == gitTreeCompare",
-                    "group": "1_state"
-                },
-                {
-                    "command": "gitTreeCompare.refresh",
-                    "when": "view == gitTreeCompare",
-                    "group": "navigation@3"
-                },
-                {
-                    "command": "gitTreeCompare.switchToFullDiff",
-                    "when": "view == gitTreeCompare && config.gitTreeCompare.diffMode == merge",
-                    "group": "3_options"
-                },
-                {
-                    "command": "gitTreeCompare.switchToMergeDiff",
-                    "when": "view == gitTreeCompare && config.gitTreeCompare.diffMode == full",
-                    "group": "3_options"
-                },
-                {
-                    "command": "gitTreeCompare.showCheckboxes",
-                    "when": "view == gitTreeCompare && !config.gitTreeCompare.showCheckboxes",
-                    "group": "3_options"
-                },
-                {
-                    "command": "gitTreeCompare.hideCheckboxes",
-                    "when": "view == gitTreeCompare && config.gitTreeCompare.showCheckboxes",
-                    "group": "3_options"
-                },
-                {
-                    "command": "gitTreeCompare.viewAsList",
-                    "when": "view == gitTreeCompare && !gitTreeCompare.viewAsList",
-                    "group": "navigation@1"
-                },
-                {
-                    "command": "gitTreeCompare.viewAsTree",
-                    "when": "view == gitTreeCompare && gitTreeCompare.viewAsList",
-                    "group": "navigation@1"
-                },
-                {
-                    "command": "gitTreeCompare.searchChanges",
-                    "when": "view == gitTreeCompare",
-                    "group": "2_files"
-                },
-                {
-                    "command": "gitTreeCompare.filterFiles",
-                    "when": "view == gitTreeCompare",
-                    "group": "navigation@4"
-                },
-                {
-                    "command": "gitTreeCompare.clearFilter",
-                    "when": "view == gitTreeCompare && gitTreeCompare.isFiltered",
-                    "group": "navigation@5"
-                },
-                {
-                    "submenu": "gitTreeCompare.viewAndSort",
-                    "when": "view == gitTreeCompare",
-                    "group": "0_view_and_sort"
-                }
-            ],
-            "view/item/context": [
-                {
-                    "command": "gitTreeCompare.openChanges",
-                    "when": "view == gitTreeCompare && viewItem == file && !config.gitTreeCompare.openChanges",
-                    "group": "inline"
-                },
-                {
-                    "command": "gitTreeCompare.openFile",
-                    "when": "view == gitTreeCompare && viewItem == file && config.gitTreeCompare.openChanges",
-                    "group": "inline"
-                },
-                {
-                    "command": "gitTreeCompare.discardChanges",
-                    "when": "view == gitTreeCompare && viewItem == file",
-                    "group": "inline"
-                },
-                {
-                    "command": "gitTreeCompare.discardChanges",
-                    "when": "view == gitTreeCompare && viewItem == folder",
-                    "group": "inline"
-                },
-                {
-                    "command": "gitTreeCompare.discardAllChanges",
-                    "when": "view == gitTreeCompare && viewItem == ref",
-                    "group": "inline"
-                },
-                {
-                    "command": "gitTreeCompare.openChanges",
-                    "when": "view == gitTreeCompare && viewItem == file && !config.gitTreeCompare.openChanges",
-                    "group": "1_open"
-                },
-                {
-                    "command": "gitTreeCompare.openFile",
-                    "when": "view == gitTreeCompare && viewItem == file && config.gitTreeCompare.openChanges",
-                    "group": "1_open"
-                },
-                {
-                    "command": "gitTreeCompare.discardChanges",
-                    "when": "view == gitTreeCompare && viewItem == file",
-                    "group": "2_discard"
-                },
-                {
-                    "command": "gitTreeCompare.discardChanges",
-                    "when": "view == gitTreeCompare && viewItem == folder",
-                    "group": "2_discard"
-                },
-                {
-                    "command": "gitTreeCompare.discardAllChanges",
-                    "when": "view == gitTreeCompare && viewItem == ref"
-                },
-                {
-                    "command": "gitTreeCompare.changeRepository",
-                    "when": "view == gitTreeCompare && viewItem == ref && gitOpenRepositoryCount != 1"
-                },
-                {
-                    "command": "gitTreeCompare.changeBase",
-                    "when": "view == gitTreeCompare && viewItem == ref"
-                },
-                {
-                    "command": "gitTreeCompare.changeBase",
-                    "when": "view == gitTreeCompare && viewItem == ref",
-                    "group": "inline"
-                },
-                {
-                    "command": "gitTreeCompare.openAllChanges",
-                    "when": "view == gitTreeCompare && viewItem == ref"
-                },
-                {
-                    "command": "gitTreeCompare.openAllChanges",
-                    "when": "view == gitTreeCompare && viewItem == folder"
-                },
-                {
-                    "command": "gitTreeCompare.openChangedFiles",
-                    "when": "view == gitTreeCompare && viewItem == ref"
-                },
-                {
-                    "command": "gitTreeCompare.openChangedFiles",
-                    "when": "view == gitTreeCompare && viewItem == folder"
-                },
-                {
-                    "command": "gitTreeCompare.openAllChanges",
-                    "when": "view == gitTreeCompare && viewItem == ref",
-                    "group": "inline"
-                },
-                {
-                    "command": "gitTreeCompare.openAllChanges",
-                    "when": "view == gitTreeCompare && viewItem == folder",
-                    "group": "inline"
-                },
-                {
-                    "command": "gitTreeCompare.openChangedFiles",
-                    "when": "view == gitTreeCompare && viewItem == ref",
-                    "group": "inline"
-                },
-                {
-                    "command": "gitTreeCompare.openChangedFiles",
-                    "when": "view == gitTreeCompare && viewItem == folder",
-                    "group": "inline"
-                },
-                {
-                    "command": "gitTreeCompare.switchToFullDiff",
-                    "when": "view == gitTreeCompare && viewItem == ref && config.gitTreeCompare.diffMode == merge"
-                },
-                {
-                    "command": "gitTreeCompare.switchToMergeDiff",
-                    "when": "view == gitTreeCompare && viewItem == ref && config.gitTreeCompare.diffMode == full"
-                },
-                {
-                    "command": "gitTreeCompare.copyPath",
-                    "when": "view == gitTreeCompare && viewItem == file",
-                    "group": "3_copy"
-                },
-                {
-                    "command": "gitTreeCompare.copyRelativePath",
-                    "when": "view == gitTreeCompare && viewItem == file",
-                    "group": "3_copy"
-                },
-                {
-                    "submenu": "gitTreeCompare.viewAndSort",
-                    "when": "view == gitTreeCompare && viewItem == ref",
-                    "group": "0_view_and_sort"
-                },
-                {
-                    "command": "gitTreeCompare.openChangesWithDifftool",
-                    "when": "view == gitTreeCompare && viewItem == file && config.gitTreeCompare.openChangesWithDifftool",
-                    "group": "1_open"
-                }
-            ]
-        },
-        "configuration": {
-            "title": "Git Tree Compare",
-            "properties": {
-                "gitTreeCompare.autoChangeRepository": {
-                    "type": "boolean",
-                    "description": "[EXPERIMENTAL] Whether to change the active repository whenever a different one is selected in the SCM view. Note that this only works well when not selecting multiple repositories. See GitHub issue #70 for more details.",
-                    "default": false
-                },
-                "gitTreeCompare.autoRefresh": {
-                    "type": "boolean",
-                    "description": "Whether to refresh the tree whenever a file in the workspace changes.",
-                    "default": true
-                },
-                "gitTreeCompare.refreshIndex": {
-                    "type": "boolean",
-                    "description": "Whether to refresh the git index each time the tree is refreshed. This avoids superfluous diff entries for cases when only the file modification date is changed, at the cost of an extra git invocation.",
-                    "default": true
-                },
-                "gitTreeCompare.findRenames": {
-                    "type": "boolean",
-                    "description": "Whether to detect renames. Does not affect untracked files. May have a performance impact.",
-                    "default": true
-                },
-                "gitTreeCompare.renameThreshold": {
-                    "type": "number",
-                    "minimum": 0,
-                    "maximum": 100,
-                    "description": "The similarity index (in percent) for rename detection. A value of 100 means that only identical files are detected as renames, a value of 0 means that any file with any similarity is detected as a rename. Has no effect if gitTreeCompare.findRenames is false.",
-                    "default": 50
-                },
-                "gitTreeCompare.openChanges": {
-                    "type": "boolean",
-                    "description": "When selecting a modified file in the tree, whether to show its changes or just open the workspace file.",
-                    "default": true
-                },
-                "gitTreeCompare.root": {
-                    "type": "string",
-                    "enum": [
-                        "workspace",
-                        "repository"
-                    ],
-                    "description": "The root of the tree when the workspace folder is not the same as the repository root.",
-                    "default": "workspace"
-                },
-                "gitTreeCompare.includeFilesOutsideWorkspaceRoot": {
-                    "type": "boolean",
-                    "description": "If gitTreeCompare.root is \"workspace\", whether to display files which are within the repository but outside the workspace folder in a special \"/\" folder.",
-                    "default": true
-                },
-                "gitTreeCompare.diffMode": {
-                    "type": "string",
-                    "enum": [
-                        "merge",
-                        "full"
-                    ],
-                    "description": "Whether to compare against the selected base ref directly (full mode) or by computing a merge base first (merge mode).",
-                    "default": "merge"
-                },
-                "gitTreeCompare.iconsMinimal": {
-                    "type": "boolean",
-                    "description": "Whether to use a compact icon alignment (like Seti file icon theme) where only files have icons.",
-                    "default": false
-                },
-                "gitTreeCompare.collapsed": {
-                    "type": "boolean",
-                    "description": "Whether to show folders collapsed instead of expanded. NOTE: A restart is required when changing this setting.",
-                    "default": false
-                },
-                "gitTreeCompare.compactFolders": {
-                    "type": "boolean",
-                    "description": "Whether to compact (flatten) single-child folders into a single tree element. Useful for Java package structures, for example. May have a performance impact for large diff trees.",
-                    "default": true
-                },
-                "gitTreeCompare.showCheckboxes": {
-                    "type": "boolean",
-                    "description": "Whether to show checkboxes such that files or folders can be ticked off, for example when reviewing.",
-                    "default": false
-                },
-                "gitTreeCompare.resetCheckboxOnFileChange": {
-                    "type": "boolean",
-                    "description": "When enabled, automatically resets checkboxes when a file is modified after being checked. This ensures that checked files reflect their reviewed state, and any subsequent modifications require re-review.",
-                    "default": false
-                },
-                "gitTreeCompare.refSortOrder": {
-                    "type": "string",
-                    "enum": [
-                        "alphabetically",
-                        "committerdate"
-                    ],
-                    "description": "How to sort refs (branches, tags) when changing the comparison base. 'committerdate' sorts by most recently committed first.",
-                    "default": "committerdate"
-                },
-                "gitTreeCompare.omitUntrackedFiles": {
-                    "type": "boolean",
-                    "description": "Whether to omit untracked files from the diff. When enabled, files that are not tracked by git will not appear in the tree.",
-                    "default": false
-                },
-                "gitTreeCompare.omitUnstagedChanges": {
-                    "type": "boolean",
-                    "description": "Whether to omit unstaged changes from the diff. When enabled, only staged changes will appear in the tree.",
-                    "default": false
-                },
-                "gitTreeCompare.sortOrder": {
-                    "type": "string",
-                    "enum": [
-                        "name",
-                        "path",
-                        "status",
-                        "recentlyModified"
-                    ],
-                    "description": "How to sort files when viewing as list. Only applies in list view mode. 'name' sorts by file name, 'path' sorts by full path, 'status' sorts by git status, 'recentlyModified' sorts by modification date with most recent first.",
-                    "default": "path"
-                },
-                "gitTreeCompare.autoReveal": {
-                    "type": "boolean",
-                    "description": "Whether to automatically reveal and select the tree item corresponding to the currently active editor.",
-                    "default": true
-                },
-                "gitTreeCompare.openChangesWithDifftool": {
-                    "type": "boolean",
-                    "description": "Whether to show the 'Open Changes with Difftool' command in the context menu for files. This command opens the changes in the external diff tool configured in Git (e.g., via 'git config diff.tool').",
-                    "default": false
-                }
-            }
-        }
-    },
-    "scripts": {
-        "vscode:prepublish": "webpack --mode production",
-        "compile": "webpack --mode none",
-        "watch": "webpack --mode none --watch --env development",
-        "test-compile": "tsc -p ./"
-    },
-    "devDependencies": {
-        "@types/byline": "4.2.31",
-        "@types/file-type": "^5.2.1",
-        "@types/node": "^13.5.0",
-        "@types/vscode": "^1.81.0",
-        "@types/which": "^1.0.28",
-        "@vscode/vsce": "^2.20.1",
-        "ts-loader": "^9.2.6",
-        "typescript": "^4.4.3",
-        "webpack": "^5.44.0",
-        "webpack-cli": "^4.2.0"
-    },
-    "dependencies": {
-        "@octokit/rest": "^22.0.1",
-        "@vscode/iconv-lite-umd": "0.7.0",
-        "byline": "^5.0.0",
-        "file-type": "^7.2.0",
-        "jschardet": "3.0.0",
-        "vscode-nls": "^4.0.0",
-        "which": "^1.3.0"
+  "name": "git-tree-compare",
+  "displayName": "Git Tree Compare",
+  "description": "Diff your worktree against a branch, tag, or commit in a tree -- especially useful for pull request preparation or merge preview",
+  "version": "1.20.0",
+  "author": {
+    "name": "Maik Riechert",
+    "url": "https://github.com/letmaik"
+  },
+  "publisher": "letmaik",
+  "license": "MIT",
+  "icon": "resources/logo.png",
+  "categories": [
+    "Other"
+  ],
+  "keywords": [
+    "git",
+    "diff",
+    "tree",
+    "compare",
+    "branch"
+  ],
+  "bugs": {
+    "url": "https://github.com/letmaik/vscode-git-tree-compare/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/letmaik/vscode-git-tree-compare.git"
+  },
+  "homepage": "https://github.com/letmaik/vscode-git-tree-compare",
+  "engines": {
+    "vscode": "^1.81.0"
+  },
+  "capabilities": {
+    "virtualWorkspaces": false,
+    "untrustedWorkspaces": {
+      "supported": true
     }
+  },
+  "extensionDependencies": [
+    "vscode.git"
+  ],
+  "main": "./dist/extension",
+  "contributes": {
+    "viewsContainers": {
+      "activitybar": [
+        {
+          "id": "gitTreeCompare",
+          "icon": "./resources/logo.svg",
+          "title": "Git Tree Compare"
+        }
+      ]
+    },
+    "views": {
+      "gitTreeCompare": [
+        {
+          "id": "gitTreeCompare",
+          "name": "none",
+          "when": "config.git.enabled && gitOpenRepositoryCount != 0",
+          "icon": "./resources/logo.svg"
+        }
+      ]
+    },
+    "commands": [
+      {
+        "command": "gitTreeCompare.changeRepository",
+        "title": "Change Repository...",
+        "icon": "$(repo)",
+        "category": "Git Tree Compare"
+      },
+      {
+        "command": "gitTreeCompare.openChanges",
+        "title": "Open Changes",
+        "icon": "$(git-compare)",
+        "category": "Git Tree Compare"
+      },
+      {
+        "command": "gitTreeCompare.openFile",
+        "title": "Open File",
+        "icon": "$(go-to-file)",
+        "category": "Git Tree Compare"
+      },
+      {
+        "command": "gitTreeCompare.discardChanges",
+        "title": "Discard Changes",
+        "icon": "$(discard)",
+        "category": "Git Tree Compare"
+      },
+      {
+        "command": "gitTreeCompare.discardAllChanges",
+        "title": "Discard All Changes",
+        "icon": "$(discard)",
+        "category": "Git Tree Compare"
+      },
+      {
+        "command": "gitTreeCompare.openAllChanges",
+        "title": "Open All Changes",
+        "icon": "$(git-compare)",
+        "category": "Git Tree Compare"
+      },
+      {
+        "command": "gitTreeCompare.openChangedFiles",
+        "title": "Open Changed Files",
+        "icon": "$(go-to-file)",
+        "category": "Git Tree Compare"
+      },
+      {
+        "command": "gitTreeCompare.changeBase",
+        "title": "Change Base...",
+        "icon": "$(git-branch)",
+        "category": "Git Tree Compare"
+      },
+      {
+        "command": "gitTreeCompare.refresh",
+        "title": "Refresh",
+        "icon": "$(refresh)",
+        "category": "Git Tree Compare"
+      },
+      {
+        "command": "gitTreeCompare.switchToFullDiff",
+        "title": "Switch to Full Diff",
+        "category": "Git Tree Compare"
+      },
+      {
+        "command": "gitTreeCompare.switchToMergeDiff",
+        "title": "Switch to Merge Diff",
+        "category": "Git Tree Compare"
+      },
+      {
+        "command": "gitTreeCompare.showCheckboxes",
+        "title": "Show checkboxes",
+        "category": "Git Tree Compare"
+      },
+      {
+        "command": "gitTreeCompare.hideCheckboxes",
+        "title": "Hide checkboxes",
+        "category": "Git Tree Compare"
+      },
+      {
+        "command": "gitTreeCompare.viewAsList",
+        "title": "View as List",
+        "icon": "$(list-flat)",
+        "category": "Git Tree Compare"
+      },
+      {
+        "command": "gitTreeCompare.viewAsTree",
+        "title": "View as Tree",
+        "icon": "$(list-tree)",
+        "category": "Git Tree Compare"
+      },
+      {
+        "command": "gitTreeCompare.searchChanges",
+        "title": "Search Changes",
+        "icon": "$(search)",
+        "category": "Git Tree Compare"
+      },
+      {
+        "command": "gitTreeCompare.filterFiles",
+        "title": "Filter Files",
+        "icon": "$(filter)",
+        "category": "Git Tree Compare"
+      },
+      {
+        "command": "gitTreeCompare.clearFilter",
+        "title": "Clear Filter",
+        "icon": "$(clear-all)",
+        "category": "Git Tree Compare"
+      },
+      {
+        "command": "gitTreeCompare.copyPath",
+        "title": "Copy Path",
+        "category": "Git Tree Compare"
+      },
+      {
+        "command": "gitTreeCompare.copyRelativePath",
+        "title": "Copy Relative Path",
+        "category": "Git Tree Compare"
+      },
+      {
+        "command": "gitTreeCompare.compareGitHubPullRequest",
+        "title": "Compare GitHub Pull Request...",
+        "icon": "$(github)",
+        "category": "Git Tree Compare"
+      },
+      {
+        "command": "gitTreeCompare.sortByName",
+        "title": "Sort by Name",
+        "category": "Git Tree Compare",
+        "enablement": "gitTreeCompare.viewAsList"
+      },
+      {
+        "command": "gitTreeCompare.sortByPath",
+        "title": "Sort by Path",
+        "category": "Git Tree Compare",
+        "enablement": "gitTreeCompare.viewAsList"
+      },
+      {
+        "command": "gitTreeCompare.sortByStatus",
+        "title": "Sort by Status",
+        "category": "Git Tree Compare",
+        "enablement": "gitTreeCompare.viewAsList"
+      },
+      {
+        "command": "gitTreeCompare.sortByRecentlyModified",
+        "title": "Sort by Recently Modified",
+        "category": "Git Tree Compare",
+        "enablement": "gitTreeCompare.viewAsList"
+      },
+      {
+        "command": "gitTreeCompare.openChangesWithDifftool",
+        "title": "Open Changes with Difftool",
+        "category": "Git Tree Compare"
+      }
+    ],
+    "submenus": [
+      {
+        "id": "gitTreeCompare.viewAndSort",
+        "label": "View & Sort"
+      }
+    ],
+    "menus": {
+      "gitTreeCompare.viewAndSort": [
+        {
+          "command": "gitTreeCompare.viewAsList",
+          "group": "1_view@1"
+        },
+        {
+          "command": "gitTreeCompare.viewAsTree",
+          "group": "1_view@2"
+        },
+        {
+          "command": "gitTreeCompare.sortByName",
+          "group": "2_sort@1",
+          "enablement": "gitTreeCompare.viewAsList"
+        },
+        {
+          "command": "gitTreeCompare.sortByPath",
+          "group": "2_sort@2",
+          "enablement": "gitTreeCompare.viewAsList"
+        },
+        {
+          "command": "gitTreeCompare.sortByStatus",
+          "group": "2_sort@3",
+          "enablement": "gitTreeCompare.viewAsList"
+        },
+        {
+          "command": "gitTreeCompare.sortByRecentlyModified",
+          "group": "2_sort@4",
+          "enablement": "gitTreeCompare.viewAsList"
+        }
+      ],
+      "view/title": [
+        {
+          "command": "gitTreeCompare.changeBase",
+          "when": "view == gitTreeCompare && gitOpenRepositoryCount == 1",
+          "group": "1_state"
+        },
+        {
+          "command": "gitTreeCompare.compareGitHubPullRequest",
+          "when": "view == gitTreeCompare && gitOpenRepositoryCount == 1",
+          "group": "1_state"
+        },
+        {
+          "command": "gitTreeCompare.openAllChanges",
+          "when": "view == gitTreeCompare && gitOpenRepositoryCount == 1",
+          "group": "2_files"
+        },
+        {
+          "command": "gitTreeCompare.openChangedFiles",
+          "when": "view == gitTreeCompare && gitOpenRepositoryCount == 1",
+          "group": "2_files"
+        },
+        {
+          "command": "gitTreeCompare.discardAllChanges",
+          "when": "view == gitTreeCompare && gitOpenRepositoryCount == 1",
+          "group": "2_files"
+        },
+        {
+          "command": "gitTreeCompare.refresh",
+          "when": "view == gitTreeCompare && gitOpenRepositoryCount == 1",
+          "group": "1_state"
+        },
+        {
+          "command": "gitTreeCompare.refresh",
+          "when": "view == gitTreeCompare && gitOpenRepositoryCount == 1",
+          "group": "navigation@3"
+        },
+        {
+          "command": "gitTreeCompare.switchToFullDiff",
+          "when": "view == gitTreeCompare && config.gitTreeCompare.diffMode == merge",
+          "group": "3_options"
+        },
+        {
+          "command": "gitTreeCompare.switchToMergeDiff",
+          "when": "view == gitTreeCompare && config.gitTreeCompare.diffMode == full",
+          "group": "3_options"
+        },
+        {
+          "command": "gitTreeCompare.showCheckboxes",
+          "when": "view == gitTreeCompare && !config.gitTreeCompare.showCheckboxes",
+          "group": "3_options"
+        },
+        {
+          "command": "gitTreeCompare.hideCheckboxes",
+          "when": "view == gitTreeCompare && config.gitTreeCompare.showCheckboxes",
+          "group": "3_options"
+        },
+        {
+          "command": "gitTreeCompare.viewAsList",
+          "when": "view == gitTreeCompare && !gitTreeCompare.viewAsList",
+          "group": "navigation@1"
+        },
+        {
+          "command": "gitTreeCompare.viewAsTree",
+          "when": "view == gitTreeCompare && gitTreeCompare.viewAsList",
+          "group": "navigation@1"
+        },
+        {
+          "command": "gitTreeCompare.searchChanges",
+          "when": "view == gitTreeCompare && gitOpenRepositoryCount == 1",
+          "group": "2_files"
+        },
+        {
+          "command": "gitTreeCompare.filterFiles",
+          "when": "view == gitTreeCompare && gitOpenRepositoryCount == 1",
+          "group": "navigation@4"
+        },
+        {
+          "command": "gitTreeCompare.clearFilter",
+          "when": "view == gitTreeCompare && gitOpenRepositoryCount == 1 && gitTreeCompare.isFiltered",
+          "group": "navigation@5"
+        },
+        {
+          "submenu": "gitTreeCompare.viewAndSort",
+          "when": "view == gitTreeCompare",
+          "group": "0_view_and_sort"
+        }
+      ],
+      "view/item/context": [
+        {
+          "command": "gitTreeCompare.changeBase",
+          "when": "view == gitTreeCompare && viewItem == repo",
+          "group": "inline@1"
+        },
+        {
+          "command": "gitTreeCompare.openAllChanges",
+          "when": "view == gitTreeCompare && viewItem == repo",
+          "group": "inline@2"
+        },
+        {
+          "command": "gitTreeCompare.openChangedFiles",
+          "when": "view == gitTreeCompare && viewItem == repo",
+          "group": "inline@3"
+        },
+        {
+          "command": "gitTreeCompare.refresh",
+          "when": "view == gitTreeCompare && viewItem == repo",
+          "group": "inline@4"
+        },
+        {
+          "command": "gitTreeCompare.filterFiles",
+          "when": "view == gitTreeCompare && viewItem == repo",
+          "group": "inline@5"
+        },
+        {
+          "command": "gitTreeCompare.discardAllChanges",
+          "when": "view == gitTreeCompare && viewItem == repo"
+        },
+        {
+          "command": "gitTreeCompare.compareGitHubPullRequest",
+          "when": "view == gitTreeCompare && viewItem == repo"
+        },
+        {
+          "command": "gitTreeCompare.searchChanges",
+          "when": "view == gitTreeCompare && viewItem == repo"
+        },
+        {
+          "command": "gitTreeCompare.clearFilter",
+          "when": "view == gitTreeCompare && viewItem == repo && gitTreeCompare.isFiltered"
+        },
+        {
+          "command": "gitTreeCompare.openChanges",
+          "when": "view == gitTreeCompare && viewItem == file && !config.gitTreeCompare.openChanges",
+          "group": "inline"
+        },
+        {
+          "command": "gitTreeCompare.openFile",
+          "when": "view == gitTreeCompare && viewItem == file && config.gitTreeCompare.openChanges",
+          "group": "inline"
+        },
+        {
+          "command": "gitTreeCompare.discardChanges",
+          "when": "view == gitTreeCompare && viewItem == file",
+          "group": "inline"
+        },
+        {
+          "command": "gitTreeCompare.discardChanges",
+          "when": "view == gitTreeCompare && viewItem == folder",
+          "group": "inline"
+        },
+        {
+          "command": "gitTreeCompare.discardAllChanges",
+          "when": "view == gitTreeCompare && viewItem == ref",
+          "group": "inline"
+        },
+        {
+          "command": "gitTreeCompare.openChanges",
+          "when": "view == gitTreeCompare && viewItem == file && !config.gitTreeCompare.openChanges",
+          "group": "1_open"
+        },
+        {
+          "command": "gitTreeCompare.openFile",
+          "when": "view == gitTreeCompare && viewItem == file && config.gitTreeCompare.openChanges",
+          "group": "1_open"
+        },
+        {
+          "command": "gitTreeCompare.discardChanges",
+          "when": "view == gitTreeCompare && viewItem == file",
+          "group": "2_discard"
+        },
+        {
+          "command": "gitTreeCompare.discardChanges",
+          "when": "view == gitTreeCompare && viewItem == folder",
+          "group": "2_discard"
+        },
+        {
+          "command": "gitTreeCompare.discardAllChanges",
+          "when": "view == gitTreeCompare && viewItem == ref"
+        },
+        {
+          "command": "gitTreeCompare.changeBase",
+          "when": "view == gitTreeCompare && viewItem == ref"
+        },
+        {
+          "command": "gitTreeCompare.changeBase",
+          "when": "view == gitTreeCompare && viewItem == ref",
+          "group": "inline"
+        },
+        {
+          "command": "gitTreeCompare.openAllChanges",
+          "when": "view == gitTreeCompare && viewItem == ref"
+        },
+        {
+          "command": "gitTreeCompare.openAllChanges",
+          "when": "view == gitTreeCompare && viewItem == folder"
+        },
+        {
+          "command": "gitTreeCompare.openChangedFiles",
+          "when": "view == gitTreeCompare && viewItem == ref"
+        },
+        {
+          "command": "gitTreeCompare.openChangedFiles",
+          "when": "view == gitTreeCompare && viewItem == folder"
+        },
+        {
+          "command": "gitTreeCompare.openAllChanges",
+          "when": "view == gitTreeCompare && viewItem == ref",
+          "group": "inline"
+        },
+        {
+          "command": "gitTreeCompare.openAllChanges",
+          "when": "view == gitTreeCompare && viewItem == folder",
+          "group": "inline"
+        },
+        {
+          "command": "gitTreeCompare.openChangedFiles",
+          "when": "view == gitTreeCompare && viewItem == ref",
+          "group": "inline"
+        },
+        {
+          "command": "gitTreeCompare.openChangedFiles",
+          "when": "view == gitTreeCompare && viewItem == folder",
+          "group": "inline"
+        },
+        {
+          "command": "gitTreeCompare.switchToFullDiff",
+          "when": "view == gitTreeCompare && viewItem == ref && config.gitTreeCompare.diffMode == merge"
+        },
+        {
+          "command": "gitTreeCompare.switchToMergeDiff",
+          "when": "view == gitTreeCompare && viewItem == ref && config.gitTreeCompare.diffMode == full"
+        },
+        {
+          "command": "gitTreeCompare.copyPath",
+          "when": "view == gitTreeCompare && viewItem == file",
+          "group": "3_copy"
+        },
+        {
+          "command": "gitTreeCompare.copyRelativePath",
+          "when": "view == gitTreeCompare && viewItem == file",
+          "group": "3_copy"
+        },
+        {
+          "submenu": "gitTreeCompare.viewAndSort",
+          "when": "view == gitTreeCompare && (viewItem == ref || viewItem == repo)",
+          "group": "0_view_and_sort"
+        },
+        {
+          "command": "gitTreeCompare.openChangesWithDifftool",
+          "when": "view == gitTreeCompare && viewItem == file && config.gitTreeCompare.openChangesWithDifftool",
+          "group": "1_open"
+        }
+      ]
+    },
+    "configuration": {
+      "title": "Git Tree Compare",
+      "properties": {
+        "gitTreeCompare.autoChangeRepository": {
+          "type": "boolean",
+          "description": "[EXPERIMENTAL] Whether to change the active repository whenever a different one is selected in the SCM view. Note that this only works well when not selecting multiple repositories. See GitHub issue #70 for more details.",
+          "default": false
+        },
+        "gitTreeCompare.autoRefresh": {
+          "type": "boolean",
+          "description": "Whether to refresh the tree whenever a file in the workspace changes.",
+          "default": true
+        },
+        "gitTreeCompare.refreshIndex": {
+          "type": "boolean",
+          "description": "Whether to refresh the git index each time the tree is refreshed. This avoids superfluous diff entries for cases when only the file modification date is changed, at the cost of an extra git invocation.",
+          "default": true
+        },
+        "gitTreeCompare.findRenames": {
+          "type": "boolean",
+          "description": "Whether to detect renames. Does not affect untracked files. May have a performance impact.",
+          "default": true
+        },
+        "gitTreeCompare.renameThreshold": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 100,
+          "description": "The similarity index (in percent) for rename detection. A value of 100 means that only identical files are detected as renames, a value of 0 means that any file with any similarity is detected as a rename. Has no effect if gitTreeCompare.findRenames is false.",
+          "default": 50
+        },
+        "gitTreeCompare.openChanges": {
+          "type": "boolean",
+          "description": "When selecting a modified file in the tree, whether to show its changes or just open the workspace file.",
+          "default": true
+        },
+        "gitTreeCompare.root": {
+          "type": "string",
+          "enum": [
+            "workspace",
+            "repository"
+          ],
+          "description": "The root of the tree when the workspace folder is not the same as the repository root.",
+          "default": "workspace"
+        },
+        "gitTreeCompare.includeFilesOutsideWorkspaceRoot": {
+          "type": "boolean",
+          "description": "If gitTreeCompare.root is \"workspace\", whether to display files which are within the repository but outside the workspace folder in a special \"/\" folder.",
+          "default": true
+        },
+        "gitTreeCompare.diffMode": {
+          "type": "string",
+          "enum": [
+            "merge",
+            "full"
+          ],
+          "description": "Whether to compare against the selected base ref directly (full mode) or by computing a merge base first (merge mode).",
+          "default": "merge"
+        },
+        "gitTreeCompare.iconsMinimal": {
+          "type": "boolean",
+          "description": "Whether to use a compact icon alignment (like Seti file icon theme) where only files have icons.",
+          "default": false
+        },
+        "gitTreeCompare.collapsed": {
+          "type": "boolean",
+          "description": "Whether to show folders collapsed instead of expanded. NOTE: A restart is required when changing this setting.",
+          "default": false
+        },
+        "gitTreeCompare.compactFolders": {
+          "type": "boolean",
+          "description": "Whether to compact (flatten) single-child folders into a single tree element. Useful for Java package structures, for example. May have a performance impact for large diff trees.",
+          "default": true
+        },
+        "gitTreeCompare.showCheckboxes": {
+          "type": "boolean",
+          "description": "Whether to show checkboxes such that files or folders can be ticked off, for example when reviewing.",
+          "default": false
+        },
+        "gitTreeCompare.resetCheckboxOnFileChange": {
+          "type": "boolean",
+          "description": "When enabled, automatically resets checkboxes when a file is modified after being checked. This ensures that checked files reflect their reviewed state, and any subsequent modifications require re-review.",
+          "default": false
+        },
+        "gitTreeCompare.refSortOrder": {
+          "type": "string",
+          "enum": [
+            "alphabetically",
+            "committerdate"
+          ],
+          "description": "How to sort refs (branches, tags) when changing the comparison base. 'committerdate' sorts by most recently committed first.",
+          "default": "committerdate"
+        },
+        "gitTreeCompare.omitUntrackedFiles": {
+          "type": "boolean",
+          "description": "Whether to omit untracked files from the diff. When enabled, files that are not tracked by git will not appear in the tree.",
+          "default": false
+        },
+        "gitTreeCompare.omitUnstagedChanges": {
+          "type": "boolean",
+          "description": "Whether to omit unstaged changes from the diff. When enabled, only staged changes will appear in the tree.",
+          "default": false
+        },
+        "gitTreeCompare.sortOrder": {
+          "type": "string",
+          "enum": [
+            "name",
+            "path",
+            "status",
+            "recentlyModified"
+          ],
+          "description": "How to sort files when viewing as list. Only applies in list view mode. 'name' sorts by file name, 'path' sorts by full path, 'status' sorts by git status, 'recentlyModified' sorts by modification date with most recent first.",
+          "default": "path"
+        },
+        "gitTreeCompare.autoReveal": {
+          "type": "boolean",
+          "description": "Whether to automatically reveal and select the tree item corresponding to the currently active editor.",
+          "default": true
+        },
+        "gitTreeCompare.openChangesWithDifftool": {
+          "type": "boolean",
+          "description": "Whether to show the 'Open Changes with Difftool' command in the context menu for files. This command opens the changes in the external diff tool configured in Git (e.g., via 'git config diff.tool').",
+          "default": false
+        }
+      }
+    }
+  },
+  "scripts": {
+    "vscode:prepublish": "webpack --mode production",
+    "compile": "webpack --mode none",
+    "watch": "webpack --mode none --watch --env development",
+    "test-compile": "tsc -p ./"
+  },
+  "devDependencies": {
+    "@types/byline": "4.2.31",
+    "@types/file-type": "^5.2.1",
+    "@types/node": "^13.5.0",
+    "@types/vscode": "^1.81.0",
+    "@types/which": "^1.0.28",
+    "@vscode/vsce": "^2.20.1",
+    "ts-loader": "^9.2.6",
+    "typescript": "^4.4.3",
+    "webpack": "^5.44.0",
+    "webpack-cli": "^4.2.0"
+  },
+  "dependencies": {
+    "@octokit/rest": "^22.0.1",
+    "@vscode/iconv-lite-umd": "0.7.0",
+    "byline": "^5.0.0",
+    "file-type": "^7.2.0",
+    "jschardet": "3.0.0",
+    "vscode-nls": "^4.0.0",
+    "which": "^1.3.0"
+  },
+  "packageManager": "pnpm@10.33.2"
 }

--- a/package.json
+++ b/package.json
@@ -669,6 +669,5 @@
     "jschardet": "3.0.0",
     "vscode-nls": "^4.0.0",
     "which": "^1.3.0"
-  },
-  "packageManager": "pnpm@10.33.2"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,730 +1,730 @@
 {
-  "name": "git-tree-compare",
-  "displayName": "Git Tree Compare",
-  "description": "Diff your worktree against a branch, tag, or commit in a tree -- especially useful for pull request preparation or merge preview",
-  "version": "1.20.0",
-  "author": {
-    "name": "Maik Riechert",
-    "url": "https://github.com/letmaik"
-  },
-  "publisher": "letmaik",
-  "license": "MIT",
-  "icon": "resources/logo.png",
-  "categories": [
-    "Other"
-  ],
-  "keywords": [
-    "git",
-    "diff",
-    "tree",
-    "compare",
-    "branch"
-  ],
-  "bugs": {
-    "url": "https://github.com/letmaik/vscode-git-tree-compare/issues"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/letmaik/vscode-git-tree-compare.git"
-  },
-  "homepage": "https://github.com/letmaik/vscode-git-tree-compare",
-  "engines": {
-    "vscode": "^1.81.0"
-  },
-  "capabilities": {
-    "virtualWorkspaces": false,
-    "untrustedWorkspaces": {
-      "supported": true
-    }
-  },
-  "extensionDependencies": [
-    "vscode.git"
-  ],
-  "main": "./dist/extension",
-  "contributes": {
-    "viewsContainers": {
-      "activitybar": [
-        {
-          "id": "gitTreeCompare",
-          "icon": "./resources/logo.svg",
-          "title": "Git Tree Compare"
-        }
-      ]
+    "name": "git-tree-compare",
+    "displayName": "Git Tree Compare",
+    "description": "Diff your worktree against a branch, tag, or commit in a tree -- especially useful for pull request preparation or merge preview",
+    "version": "1.20.0",
+    "author": {
+        "name": "Maik Riechert",
+        "url": "https://github.com/letmaik"
     },
-    "views": {
-      "gitTreeCompare": [
-        {
-          "id": "gitTreeCompare",
-          "name": "none",
-          "when": "config.git.enabled && gitOpenRepositoryCount != 0",
-          "icon": "./resources/logo.svg"
-        }
-      ]
-    },
-    "commands": [
-      {
-        "command": "gitTreeCompare.changeRepository",
-        "title": "Change Repository...",
-        "icon": "$(repo)",
-        "category": "Git Tree Compare"
-      },
-      {
-        "command": "gitTreeCompare.openChanges",
-        "title": "Open Changes",
-        "icon": "$(git-compare)",
-        "category": "Git Tree Compare"
-      },
-      {
-        "command": "gitTreeCompare.openFile",
-        "title": "Open File",
-        "icon": "$(go-to-file)",
-        "category": "Git Tree Compare"
-      },
-      {
-        "command": "gitTreeCompare.discardChanges",
-        "title": "Discard Changes",
-        "icon": "$(discard)",
-        "category": "Git Tree Compare"
-      },
-      {
-        "command": "gitTreeCompare.discardAllChanges",
-        "title": "Discard All Changes",
-        "icon": "$(discard)",
-        "category": "Git Tree Compare"
-      },
-      {
-        "command": "gitTreeCompare.openAllChanges",
-        "title": "Open All Changes",
-        "icon": "$(git-compare)",
-        "category": "Git Tree Compare"
-      },
-      {
-        "command": "gitTreeCompare.openChangedFiles",
-        "title": "Open Changed Files",
-        "icon": "$(go-to-file)",
-        "category": "Git Tree Compare"
-      },
-      {
-        "command": "gitTreeCompare.changeBase",
-        "title": "Change Base...",
-        "icon": "$(git-branch)",
-        "category": "Git Tree Compare"
-      },
-      {
-        "command": "gitTreeCompare.refresh",
-        "title": "Refresh Repository",
-        "icon": "$(refresh)",
-        "category": "Git Tree Compare"
-      },
-      {
-        "command": "gitTreeCompare.refreshAll",
-        "title": "Refresh",
-        "icon": "$(refresh)",
-        "category": "Git Tree Compare"
-      },
-      {
-        "command": "gitTreeCompare.switchToFullDiff",
-        "title": "Switch to Full Diff",
-        "category": "Git Tree Compare"
-      },
-      {
-        "command": "gitTreeCompare.switchToMergeDiff",
-        "title": "Switch to Merge Diff",
-        "category": "Git Tree Compare"
-      },
-      {
-        "command": "gitTreeCompare.showCheckboxes",
-        "title": "Show checkboxes",
-        "category": "Git Tree Compare"
-      },
-      {
-        "command": "gitTreeCompare.hideCheckboxes",
-        "title": "Hide checkboxes",
-        "category": "Git Tree Compare"
-      },
-      {
-        "command": "gitTreeCompare.viewAsList",
-        "title": "View as List",
-        "icon": "$(list-flat)",
-        "category": "Git Tree Compare"
-      },
-      {
-        "command": "gitTreeCompare.viewAsTree",
-        "title": "View as Tree",
-        "icon": "$(list-tree)",
-        "category": "Git Tree Compare"
-      },
-      {
-        "command": "gitTreeCompare.hideCheckedInTree",
-        "title": "Hide checked files",
-        "icon": "$(eye)",
-        "category": "Git Tree Compare"
-      },
-      {
-        "command": "gitTreeCompare.showCheckedInTree",
-        "title": "Show checked files",
-        "icon": "$(eye-closed)",
-        "category": "Git Tree Compare"
-      },
-      {
-        "command": "gitTreeCompare.searchChanges",
-        "title": "Search Changes",
-        "icon": "$(search)",
-        "category": "Git Tree Compare"
-      },
-      {
-        "command": "gitTreeCompare.collapseAll",
-        "title": "Collapse All",
-        "icon": "$(collapse-all)",
-        "category": "Git Tree Compare"
-      },
-      {
-        "command": "gitTreeCompare.filterFiles",
-        "title": "Filter Files",
-        "icon": "$(filter)",
-        "category": "Git Tree Compare"
-      },
-      {
-        "command": "gitTreeCompare.clearFilter",
-        "title": "Clear Filter",
-        "icon": "$(clear-all)",
-        "category": "Git Tree Compare"
-      },
-      {
-        "command": "gitTreeCompare.copyPath",
-        "title": "Copy Path",
-        "category": "Git Tree Compare"
-      },
-      {
-        "command": "gitTreeCompare.copyRelativePath",
-        "title": "Copy Relative Path",
-        "category": "Git Tree Compare"
-      },
-      {
-        "command": "gitTreeCompare.compareGitHubPullRequest",
-        "title": "Compare GitHub Pull Request...",
-        "icon": "$(github)",
-        "category": "Git Tree Compare"
-      },
-      {
-        "command": "gitTreeCompare.sortByName",
-        "title": "Sort by Name",
-        "category": "Git Tree Compare",
-        "enablement": "gitTreeCompare.viewAsList"
-      },
-      {
-        "command": "gitTreeCompare.sortByPath",
-        "title": "Sort by Path",
-        "category": "Git Tree Compare",
-        "enablement": "gitTreeCompare.viewAsList"
-      },
-      {
-        "command": "gitTreeCompare.sortByStatus",
-        "title": "Sort by Status",
-        "category": "Git Tree Compare",
-        "enablement": "gitTreeCompare.viewAsList"
-      },
-      {
-        "command": "gitTreeCompare.sortByRecentlyModified",
-        "title": "Sort by Recently Modified",
-        "category": "Git Tree Compare",
-        "enablement": "gitTreeCompare.viewAsList"
-      },
-      {
-        "command": "gitTreeCompare.openChangesWithDifftool",
-        "title": "Open Changes with Difftool",
-        "category": "Git Tree Compare"
-      }
+    "publisher": "letmaik",
+    "license": "MIT",
+    "icon": "resources/logo.png",
+    "categories": [
+        "Other"
     ],
-    "submenus": [
-      {
-        "id": "gitTreeCompare.viewAndSort",
-        "label": "View & Sort"
-      }
+    "keywords": [
+        "git",
+        "diff",
+        "tree",
+        "compare",
+        "branch"
     ],
-    "menus": {
-      "gitTreeCompare.viewAndSort": [
-        {
-          "command": "gitTreeCompare.viewAsList",
-          "group": "1_view@1"
-        },
-        {
-          "command": "gitTreeCompare.viewAsTree",
-          "group": "1_view@2"
-        },
-        {
-          "command": "gitTreeCompare.sortByName",
-          "group": "2_sort@1",
-          "enablement": "gitTreeCompare.viewAsList"
-        },
-        {
-          "command": "gitTreeCompare.sortByPath",
-          "group": "2_sort@2",
-          "enablement": "gitTreeCompare.viewAsList"
-        },
-        {
-          "command": "gitTreeCompare.sortByStatus",
-          "group": "2_sort@3",
-          "enablement": "gitTreeCompare.viewAsList"
-        },
-        {
-          "command": "gitTreeCompare.sortByRecentlyModified",
-          "group": "2_sort@4",
-          "enablement": "gitTreeCompare.viewAsList"
-        }
-      ],
-      "view/title": [
-        {
-          "command": "gitTreeCompare.changeRepository",
-          "when": "view == gitTreeCompare && !config.gitTreeCompare.multiRepositoryView && gitOpenRepositoryCount != 1",
-          "group": "1_state"
-        },
-        {
-          "command": "gitTreeCompare.changeRepository",
-          "when": "view == gitTreeCompare && !config.gitTreeCompare.multiRepositoryView && gitOpenRepositoryCount != 1",
-          "group": "navigation@2"
-        },
-        {
-          "command": "gitTreeCompare.changeBase",
-          "when": "view == gitTreeCompare && (!config.gitTreeCompare.multiRepositoryView || gitOpenRepositoryCount == 1)",
-          "group": "1_state"
-        },
-        {
-          "command": "gitTreeCompare.compareGitHubPullRequest",
-          "when": "view == gitTreeCompare && (!config.gitTreeCompare.multiRepositoryView || gitOpenRepositoryCount == 1)",
-          "group": "1_state"
-        },
-        {
-          "command": "gitTreeCompare.openAllChanges",
-          "when": "view == gitTreeCompare && (!config.gitTreeCompare.multiRepositoryView || gitOpenRepositoryCount == 1)",
-          "group": "2_files"
-        },
-        {
-          "command": "gitTreeCompare.openChangedFiles",
-          "when": "view == gitTreeCompare && (!config.gitTreeCompare.multiRepositoryView || gitOpenRepositoryCount == 1)",
-          "group": "2_files"
-        },
-        {
-          "command": "gitTreeCompare.discardAllChanges",
-          "when": "view == gitTreeCompare && (!config.gitTreeCompare.multiRepositoryView || gitOpenRepositoryCount == 1)",
-          "group": "2_files"
-        },
-        {
-          "command": "gitTreeCompare.refreshAll",
-          "when": "view == gitTreeCompare",
-          "group": "1_state"
-        },
-        {
-          "command": "gitTreeCompare.refreshAll",
-          "when": "view == gitTreeCompare",
-          "group": "navigation@3"
-        },
-        {
-          "command": "gitTreeCompare.switchToFullDiff",
-          "when": "view == gitTreeCompare && config.gitTreeCompare.diffMode == merge",
-          "group": "3_options"
-        },
-        {
-          "command": "gitTreeCompare.switchToMergeDiff",
-          "when": "view == gitTreeCompare && config.gitTreeCompare.diffMode == full",
-          "group": "3_options"
-        },
-        {
-          "command": "gitTreeCompare.showCheckboxes",
-          "when": "view == gitTreeCompare && !config.gitTreeCompare.showCheckboxes",
-          "group": "3_options"
-        },
-        {
-          "command": "gitTreeCompare.hideCheckboxes",
-          "when": "view == gitTreeCompare && config.gitTreeCompare.showCheckboxes",
-          "group": "3_options"
-        },
-        {
-          "command": "gitTreeCompare.hideCheckedInTree",
-          "when": "view == gitTreeCompare && config.gitTreeCompare.showCheckboxes && !gitTreeCompare.hideCheckedFiles",
-          "group": "navigation@0"
-        },
-        {
-          "command": "gitTreeCompare.showCheckedInTree",
-          "when": "view == gitTreeCompare && config.gitTreeCompare.showCheckboxes && gitTreeCompare.hideCheckedFiles",
-          "group": "navigation@0"
-        },
-        {
-          "command": "gitTreeCompare.viewAsList",
-          "when": "view == gitTreeCompare && !gitTreeCompare.viewAsList",
-          "group": "navigation@1"
-        },
-        {
-          "command": "gitTreeCompare.viewAsTree",
-          "when": "view == gitTreeCompare && gitTreeCompare.viewAsList",
-          "group": "navigation@1"
-        },
-        {
-          "command": "gitTreeCompare.searchChanges",
-          "when": "view == gitTreeCompare && (!config.gitTreeCompare.multiRepositoryView || gitOpenRepositoryCount == 1)",
-          "group": "2_files"
-        },
-        {
-          "command": "gitTreeCompare.filterFiles",
-          "when": "view == gitTreeCompare && (!config.gitTreeCompare.multiRepositoryView || gitOpenRepositoryCount == 1)",
-          "group": "navigation@4"
-        },
-        {
-          "command": "gitTreeCompare.clearFilter",
-          "when": "view == gitTreeCompare && (!config.gitTreeCompare.multiRepositoryView || gitOpenRepositoryCount == 1) && gitTreeCompare.isFiltered",
-          "group": "navigation@5"
-        },
-        {
-          "command": "gitTreeCompare.collapseAll",
-          "when": "view == gitTreeCompare",
-          "group": "navigation@6"
-        },
-        {
-          "submenu": "gitTreeCompare.viewAndSort",
-          "when": "view == gitTreeCompare",
-          "group": "0_view_and_sort"
-        }
-      ],
-      "view/item/context": [
-        {
-          "command": "gitTreeCompare.changeBase",
-          "when": "view == gitTreeCompare && viewItem == repo && config.gitTreeCompare.multiRepositoryView",
-          "group": "inline@1"
-        },
-        {
-          "command": "gitTreeCompare.openAllChanges",
-          "when": "view == gitTreeCompare && viewItem == repo && config.gitTreeCompare.multiRepositoryView",
-          "group": "inline@2"
-        },
-        {
-          "command": "gitTreeCompare.openChangedFiles",
-          "when": "view == gitTreeCompare && viewItem == repo && config.gitTreeCompare.multiRepositoryView",
-          "group": "inline@3"
-        },
-        {
-          "command": "gitTreeCompare.refresh",
-          "when": "view == gitTreeCompare && viewItem == repo && config.gitTreeCompare.multiRepositoryView",
-          "group": "inline@4"
-        },
-        {
-          "command": "gitTreeCompare.filterFiles",
-          "when": "view == gitTreeCompare && viewItem == repo && config.gitTreeCompare.multiRepositoryView",
-          "group": "inline@5"
-        },
-        {
-          "command": "gitTreeCompare.discardAllChanges",
-          "when": "view == gitTreeCompare && viewItem == repo && config.gitTreeCompare.multiRepositoryView"
-        },
-        {
-          "command": "gitTreeCompare.compareGitHubPullRequest",
-          "when": "view == gitTreeCompare && viewItem == repo && config.gitTreeCompare.multiRepositoryView"
-        },
-        {
-          "command": "gitTreeCompare.searchChanges",
-          "when": "view == gitTreeCompare && viewItem == repo && config.gitTreeCompare.multiRepositoryView"
-        },
-        {
-          "command": "gitTreeCompare.clearFilter",
-          "when": "view == gitTreeCompare && viewItem == repo && config.gitTreeCompare.multiRepositoryView && gitTreeCompare.isFiltered"
-        },
-        {
-          "command": "gitTreeCompare.openChanges",
-          "when": "view == gitTreeCompare && viewItem == file && !config.gitTreeCompare.openChanges",
-          "group": "inline"
-        },
-        {
-          "command": "gitTreeCompare.openFile",
-          "when": "view == gitTreeCompare && viewItem == file && config.gitTreeCompare.openChanges",
-          "group": "inline"
-        },
-        {
-          "command": "gitTreeCompare.discardChanges",
-          "when": "view == gitTreeCompare && viewItem == file",
-          "group": "inline"
-        },
-        {
-          "command": "gitTreeCompare.discardChanges",
-          "when": "view == gitTreeCompare && viewItem == folder",
-          "group": "inline"
-        },
-        {
-          "command": "gitTreeCompare.discardAllChanges",
-          "when": "view == gitTreeCompare && viewItem == ref",
-          "group": "inline"
-        },
-        {
-          "command": "gitTreeCompare.openChanges",
-          "when": "view == gitTreeCompare && viewItem == file && !config.gitTreeCompare.openChanges",
-          "group": "1_open"
-        },
-        {
-          "command": "gitTreeCompare.openFile",
-          "when": "view == gitTreeCompare && viewItem == file && config.gitTreeCompare.openChanges",
-          "group": "1_open"
-        },
-        {
-          "command": "gitTreeCompare.discardChanges",
-          "when": "view == gitTreeCompare && viewItem == file",
-          "group": "2_discard"
-        },
-        {
-          "command": "gitTreeCompare.discardChanges",
-          "when": "view == gitTreeCompare && viewItem == folder",
-          "group": "2_discard"
-        },
-        {
-          "command": "gitTreeCompare.discardAllChanges",
-          "when": "view == gitTreeCompare && viewItem == ref"
-        },
-        {
-          "command": "gitTreeCompare.changeBase",
-          "when": "view == gitTreeCompare && viewItem == ref"
-        },
-        {
-          "command": "gitTreeCompare.changeBase",
-          "when": "view == gitTreeCompare && viewItem == ref",
-          "group": "inline"
-        },
-        {
-          "command": "gitTreeCompare.openAllChanges",
-          "when": "view == gitTreeCompare && viewItem == ref"
-        },
-        {
-          "command": "gitTreeCompare.openAllChanges",
-          "when": "view == gitTreeCompare && viewItem == folder"
-        },
-        {
-          "command": "gitTreeCompare.openChangedFiles",
-          "when": "view == gitTreeCompare && viewItem == ref"
-        },
-        {
-          "command": "gitTreeCompare.openChangedFiles",
-          "when": "view == gitTreeCompare && viewItem == folder"
-        },
-        {
-          "command": "gitTreeCompare.openAllChanges",
-          "when": "view == gitTreeCompare && viewItem == ref",
-          "group": "inline"
-        },
-        {
-          "command": "gitTreeCompare.openAllChanges",
-          "when": "view == gitTreeCompare && viewItem == folder",
-          "group": "inline"
-        },
-        {
-          "command": "gitTreeCompare.openChangedFiles",
-          "when": "view == gitTreeCompare && viewItem == ref",
-          "group": "inline"
-        },
-        {
-          "command": "gitTreeCompare.openChangedFiles",
-          "when": "view == gitTreeCompare && viewItem == folder",
-          "group": "inline"
-        },
-        {
-          "command": "gitTreeCompare.switchToFullDiff",
-          "when": "view == gitTreeCompare && viewItem == ref && config.gitTreeCompare.diffMode == merge"
-        },
-        {
-          "command": "gitTreeCompare.switchToMergeDiff",
-          "when": "view == gitTreeCompare && viewItem == ref && config.gitTreeCompare.diffMode == full"
-        },
-        {
-          "command": "gitTreeCompare.copyPath",
-          "when": "view == gitTreeCompare && viewItem == file",
-          "group": "3_copy"
-        },
-        {
-          "command": "gitTreeCompare.copyRelativePath",
-          "when": "view == gitTreeCompare && viewItem == file",
-          "group": "3_copy"
-        },
-        {
-          "submenu": "gitTreeCompare.viewAndSort",
-          "when": "view == gitTreeCompare && (viewItem == ref || (viewItem == repo && config.gitTreeCompare.multiRepositoryView))",
-          "group": "0_view_and_sort"
-        },
-        {
-          "command": "gitTreeCompare.openChangesWithDifftool",
-          "when": "view == gitTreeCompare && viewItem == file && config.gitTreeCompare.openChangesWithDifftool",
-          "group": "1_open"
-        }
-      ]
+    "bugs": {
+        "url": "https://github.com/letmaik/vscode-git-tree-compare/issues"
     },
-    "configuration": {
-      "title": "Git Tree Compare",
-      "properties": {
-        "gitTreeCompare.autoChangeRepository": {
-          "type": "boolean",
-          "description": "[EXPERIMENTAL] Whether to change the active repository whenever a different one is selected in the SCM view. Note that this only works well when not selecting multiple repositories. See GitHub issue #70 for more details.",
-          "default": false
-        },
-        "gitTreeCompare.multiRepositoryView": {
-          "type": "boolean",
-          "description": "[EXPERIMENTAL] Whether to show one expandable Git Tree Compare section per open repository instead of selecting a single active repository.",
-          "default": false
-        },
-        "gitTreeCompare.autoRefresh": {
-          "type": "boolean",
-          "description": "Whether to refresh the tree whenever a file in the workspace changes.",
-          "default": true
-        },
-        "gitTreeCompare.refreshIndex": {
-          "type": "boolean",
-          "description": "Whether to refresh the git index each time the tree is refreshed. This avoids superfluous diff entries for cases when only the file modification date is changed, at the cost of an extra git invocation.",
-          "default": true
-        },
-        "gitTreeCompare.findRenames": {
-          "type": "boolean",
-          "description": "Whether to detect renames. Does not affect untracked files. May have a performance impact.",
-          "default": true
-        },
-        "gitTreeCompare.renameThreshold": {
-          "type": "number",
-          "minimum": 0,
-          "maximum": 100,
-          "description": "The similarity index (in percent) for rename detection. A value of 100 means that only identical files are detected as renames, a value of 0 means that any file with any similarity is detected as a rename. Has no effect if gitTreeCompare.findRenames is false.",
-          "default": 50
-        },
-        "gitTreeCompare.openChanges": {
-          "type": "boolean",
-          "description": "When selecting a modified file in the tree, whether to show its changes or just open the workspace file.",
-          "default": true
-        },
-        "gitTreeCompare.root": {
-          "type": "string",
-          "enum": [
-            "workspace",
-            "repository"
-          ],
-          "description": "The root of the tree when the workspace folder is not the same as the repository root.",
-          "default": "workspace"
-        },
-        "gitTreeCompare.includeFilesOutsideWorkspaceRoot": {
-          "type": "boolean",
-          "description": "If gitTreeCompare.root is \"workspace\", whether to display files which are within the repository but outside the workspace folder in a special \"/\" folder.",
-          "default": true
-        },
-        "gitTreeCompare.diffMode": {
-          "type": "string",
-          "enum": [
-            "merge",
-            "full"
-          ],
-          "description": "Whether to compare against the selected base ref directly (full mode) or by computing a merge base first (merge mode).",
-          "default": "merge"
-        },
-        "gitTreeCompare.iconsMinimal": {
-          "type": "boolean",
-          "description": "Whether to use a compact icon alignment (like Seti file icon theme) where only files have icons.",
-          "default": false
-        },
-        "gitTreeCompare.iconStyle": {
-          "type": "string",
-          "description": "Which icon style to use for files in the compare tree.",
-          "enum": [
-            "status",
-            "fileTheme"
-          ],
-          "enumDescriptions": [
-            "Use the extension's git status icons for files.",
-            "Use VS Code file theme icons and color file labels by git status."
-          ],
-          "default": "status"
-        },
-        "gitTreeCompare.collapsed": {
-          "type": "boolean",
-          "description": "Whether to show folders collapsed instead of expanded. NOTE: A restart is required when changing this setting.",
-          "default": false
-        },
-        "gitTreeCompare.compactFolders": {
-          "type": "boolean",
-          "description": "Whether to compact (flatten) single-child folders into a single tree element. Useful for Java package structures, for example. May have a performance impact for large diff trees.",
-          "default": true
-        },
-        "gitTreeCompare.showCheckboxes": {
-          "type": "boolean",
-          "description": "Whether to show checkboxes such that files or folders can be ticked off, for example when reviewing.",
-          "default": false
-        },
-        "gitTreeCompare.resetCheckboxOnFileChange": {
-          "type": "boolean",
-          "description": "When enabled, automatically resets checkboxes when a file is modified after being checked. This ensures that checked files reflect their reviewed state, and any subsequent modifications require re-review.",
-          "default": false
-        },
-        "gitTreeCompare.refSortOrder": {
-          "type": "string",
-          "enum": [
-            "alphabetically",
-            "committerdate"
-          ],
-          "description": "How to sort refs (branches, tags) when changing the comparison base. 'committerdate' sorts by most recently committed first.",
-          "default": "committerdate"
-        },
-        "gitTreeCompare.omitUntrackedFiles": {
-          "type": "boolean",
-          "description": "Whether to omit untracked files from the diff. When enabled, files that are not tracked by git will not appear in the tree.",
-          "default": false
-        },
-        "gitTreeCompare.omitUnstagedChanges": {
-          "type": "boolean",
-          "description": "Whether to omit unstaged changes from the diff. When enabled, only staged changes will appear in the tree.",
-          "default": false
-        },
-        "gitTreeCompare.sortOrder": {
-          "type": "string",
-          "enum": [
-            "name",
-            "path",
-            "status",
-            "recentlyModified"
-          ],
-          "description": "How to sort files when viewing as list. Only applies in list view mode. 'name' sorts by file name, 'path' sorts by full path, 'status' sorts by git status, 'recentlyModified' sorts by modification date with most recent first.",
-          "default": "path"
-        },
-        "gitTreeCompare.autoReveal": {
-          "type": "boolean",
-          "description": "Whether to automatically reveal and select the tree item corresponding to the currently active editor.",
-          "default": true
-        },
-        "gitTreeCompare.openChangesWithDifftool": {
-          "type": "boolean",
-          "description": "Whether to show the 'Open Changes with Difftool' command in the context menu for files. This command opens the changes in the external diff tool configured in Git (e.g., via 'git config diff.tool').",
-          "default": false
-        },
-        "gitTreeCompare.showDiffStats": {
-          "type": "boolean",
-          "description": "Whether to show insertion/deletion counts (+N -N) next to each file.",
-          "default": false
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/letmaik/vscode-git-tree-compare.git"
+    },
+    "homepage": "https://github.com/letmaik/vscode-git-tree-compare",
+    "engines": {
+        "vscode": "^1.81.0"
+    },
+    "capabilities": {
+        "virtualWorkspaces": false,
+        "untrustedWorkspaces": {
+            "supported": true
         }
-      }
+    },
+    "extensionDependencies": [
+        "vscode.git"
+    ],
+    "main": "./dist/extension",
+    "contributes": {
+        "viewsContainers": {
+            "activitybar": [
+                {
+                    "id": "gitTreeCompare",
+                    "icon": "./resources/logo.svg",
+                    "title": "Git Tree Compare"
+                }
+            ]
+        },
+        "views": {
+            "gitTreeCompare": [
+                {
+                    "id": "gitTreeCompare",
+                    "name": "none",
+                    "when": "config.git.enabled && gitOpenRepositoryCount != 0",
+                    "icon": "./resources/logo.svg"
+                }
+            ]
+        },
+        "commands": [
+            {
+                "command": "gitTreeCompare.changeRepository",
+                "title": "Change Repository...",
+                "icon": "$(repo)",
+                "category": "Git Tree Compare"
+            },
+            {
+                "command": "gitTreeCompare.openChanges",
+                "title": "Open Changes",
+                "icon": "$(git-compare)",
+                "category": "Git Tree Compare"
+            },
+            {
+                "command": "gitTreeCompare.openFile",
+                "title": "Open File",
+                "icon": "$(go-to-file)",
+                "category": "Git Tree Compare"
+            },
+            {
+                "command": "gitTreeCompare.discardChanges",
+                "title": "Discard Changes",
+                "icon": "$(discard)",
+                "category": "Git Tree Compare"
+            },
+            {
+                "command": "gitTreeCompare.discardAllChanges",
+                "title": "Discard All Changes",
+                "icon": "$(discard)",
+                "category": "Git Tree Compare"
+            },
+            {
+                "command": "gitTreeCompare.openAllChanges",
+                "title": "Open All Changes",
+                "icon": "$(git-compare)",
+                "category": "Git Tree Compare"
+            },
+            {
+                "command": "gitTreeCompare.openChangedFiles",
+                "title": "Open Changed Files",
+                "icon": "$(go-to-file)",
+                "category": "Git Tree Compare"
+            },
+            {
+                "command": "gitTreeCompare.changeBase",
+                "title": "Change Base...",
+                "icon": "$(git-branch)",
+                "category": "Git Tree Compare"
+            },
+            {
+                "command": "gitTreeCompare.refresh",
+                "title": "Refresh Repository",
+                "icon": "$(refresh)",
+                "category": "Git Tree Compare"
+            },
+            {
+                "command": "gitTreeCompare.refreshAll",
+                "title": "Refresh",
+                "icon": "$(refresh)",
+                "category": "Git Tree Compare"
+            },
+            {
+                "command": "gitTreeCompare.switchToFullDiff",
+                "title": "Switch to Full Diff",
+                "category": "Git Tree Compare"
+            },
+            {
+                "command": "gitTreeCompare.switchToMergeDiff",
+                "title": "Switch to Merge Diff",
+                "category": "Git Tree Compare"
+            },
+            {
+                "command": "gitTreeCompare.showCheckboxes",
+                "title": "Show checkboxes",
+                "category": "Git Tree Compare"
+            },
+            {
+                "command": "gitTreeCompare.hideCheckboxes",
+                "title": "Hide checkboxes",
+                "category": "Git Tree Compare"
+            },
+            {
+                "command": "gitTreeCompare.viewAsList",
+                "title": "View as List",
+                "icon": "$(list-flat)",
+                "category": "Git Tree Compare"
+            },
+            {
+                "command": "gitTreeCompare.viewAsTree",
+                "title": "View as Tree",
+                "icon": "$(list-tree)",
+                "category": "Git Tree Compare"
+            },
+            {
+                "command": "gitTreeCompare.hideCheckedInTree",
+                "title": "Hide checked files",
+                "icon": "$(eye)",
+                "category": "Git Tree Compare"
+            },
+            {
+                "command": "gitTreeCompare.showCheckedInTree",
+                "title": "Show checked files",
+                "icon": "$(eye-closed)",
+                "category": "Git Tree Compare"
+            },
+            {
+                "command": "gitTreeCompare.searchChanges",
+                "title": "Search Changes",
+                "icon": "$(search)",
+                "category": "Git Tree Compare"
+            },
+            {
+                "command": "gitTreeCompare.collapseAll",
+                "title": "Collapse All",
+                "icon": "$(collapse-all)",
+                "category": "Git Tree Compare"
+            },
+            {
+                "command": "gitTreeCompare.filterFiles",
+                "title": "Filter Files",
+                "icon": "$(filter)",
+                "category": "Git Tree Compare"
+            },
+            {
+                "command": "gitTreeCompare.clearFilter",
+                "title": "Clear Filter",
+                "icon": "$(clear-all)",
+                "category": "Git Tree Compare"
+            },
+            {
+                "command": "gitTreeCompare.copyPath",
+                "title": "Copy Path",
+                "category": "Git Tree Compare"
+            },
+            {
+                "command": "gitTreeCompare.copyRelativePath",
+                "title": "Copy Relative Path",
+                "category": "Git Tree Compare"
+            },
+            {
+                "command": "gitTreeCompare.compareGitHubPullRequest",
+                "title": "Compare GitHub Pull Request...",
+                "icon": "$(github)",
+                "category": "Git Tree Compare"
+            },
+            {
+                "command": "gitTreeCompare.sortByName",
+                "title": "Sort by Name",
+                "category": "Git Tree Compare",
+                "enablement": "gitTreeCompare.viewAsList"
+            },
+            {
+                "command": "gitTreeCompare.sortByPath",
+                "title": "Sort by Path",
+                "category": "Git Tree Compare",
+                "enablement": "gitTreeCompare.viewAsList"
+            },
+            {
+                "command": "gitTreeCompare.sortByStatus",
+                "title": "Sort by Status",
+                "category": "Git Tree Compare",
+                "enablement": "gitTreeCompare.viewAsList"
+            },
+            {
+                "command": "gitTreeCompare.sortByRecentlyModified",
+                "title": "Sort by Recently Modified",
+                "category": "Git Tree Compare",
+                "enablement": "gitTreeCompare.viewAsList"
+            },
+            {
+                "command": "gitTreeCompare.openChangesWithDifftool",
+                "title": "Open Changes with Difftool",
+                "category": "Git Tree Compare"
+            }
+        ],
+        "submenus": [
+            {
+                "id": "gitTreeCompare.viewAndSort",
+                "label": "View & Sort"
+            }
+        ],
+        "menus": {
+            "gitTreeCompare.viewAndSort": [
+                {
+                    "command": "gitTreeCompare.viewAsList",
+                    "group": "1_view@1"
+                },
+                {
+                    "command": "gitTreeCompare.viewAsTree",
+                    "group": "1_view@2"
+                },
+                {
+                    "command": "gitTreeCompare.sortByName",
+                    "group": "2_sort@1",
+                    "enablement": "gitTreeCompare.viewAsList"
+                },
+                {
+                    "command": "gitTreeCompare.sortByPath",
+                    "group": "2_sort@2",
+                    "enablement": "gitTreeCompare.viewAsList"
+                },
+                {
+                    "command": "gitTreeCompare.sortByStatus",
+                    "group": "2_sort@3",
+                    "enablement": "gitTreeCompare.viewAsList"
+                },
+                {
+                    "command": "gitTreeCompare.sortByRecentlyModified",
+                    "group": "2_sort@4",
+                    "enablement": "gitTreeCompare.viewAsList"
+                }
+            ],
+            "view/title": [
+                {
+                    "command": "gitTreeCompare.changeRepository",
+                    "when": "view == gitTreeCompare && !config.gitTreeCompare.multiRepositoryView && gitOpenRepositoryCount != 1",
+                    "group": "1_state"
+                },
+                {
+                    "command": "gitTreeCompare.changeRepository",
+                    "when": "view == gitTreeCompare && !config.gitTreeCompare.multiRepositoryView && gitOpenRepositoryCount != 1",
+                    "group": "navigation@2"
+                },
+                {
+                    "command": "gitTreeCompare.changeBase",
+                    "when": "view == gitTreeCompare && (!config.gitTreeCompare.multiRepositoryView || gitOpenRepositoryCount == 1)",
+                    "group": "1_state"
+                },
+                {
+                    "command": "gitTreeCompare.compareGitHubPullRequest",
+                    "when": "view == gitTreeCompare && (!config.gitTreeCompare.multiRepositoryView || gitOpenRepositoryCount == 1)",
+                    "group": "1_state"
+                },
+                {
+                    "command": "gitTreeCompare.openAllChanges",
+                    "when": "view == gitTreeCompare && (!config.gitTreeCompare.multiRepositoryView || gitOpenRepositoryCount == 1)",
+                    "group": "2_files"
+                },
+                {
+                    "command": "gitTreeCompare.openChangedFiles",
+                    "when": "view == gitTreeCompare && (!config.gitTreeCompare.multiRepositoryView || gitOpenRepositoryCount == 1)",
+                    "group": "2_files"
+                },
+                {
+                    "command": "gitTreeCompare.discardAllChanges",
+                    "when": "view == gitTreeCompare && (!config.gitTreeCompare.multiRepositoryView || gitOpenRepositoryCount == 1)",
+                    "group": "2_files"
+                },
+                {
+                    "command": "gitTreeCompare.refreshAll",
+                    "when": "view == gitTreeCompare",
+                    "group": "1_state"
+                },
+                {
+                    "command": "gitTreeCompare.refreshAll",
+                    "when": "view == gitTreeCompare",
+                    "group": "navigation@3"
+                },
+                {
+                    "command": "gitTreeCompare.switchToFullDiff",
+                    "when": "view == gitTreeCompare && config.gitTreeCompare.diffMode == merge",
+                    "group": "3_options"
+                },
+                {
+                    "command": "gitTreeCompare.switchToMergeDiff",
+                    "when": "view == gitTreeCompare && config.gitTreeCompare.diffMode == full",
+                    "group": "3_options"
+                },
+                {
+                    "command": "gitTreeCompare.showCheckboxes",
+                    "when": "view == gitTreeCompare && !config.gitTreeCompare.showCheckboxes",
+                    "group": "3_options"
+                },
+                {
+                    "command": "gitTreeCompare.hideCheckboxes",
+                    "when": "view == gitTreeCompare && config.gitTreeCompare.showCheckboxes",
+                    "group": "3_options"
+                },
+                {
+                    "command": "gitTreeCompare.hideCheckedInTree",
+                    "when": "view == gitTreeCompare && config.gitTreeCompare.showCheckboxes && !gitTreeCompare.hideCheckedFiles",
+                    "group": "navigation@0"
+                },
+                {
+                    "command": "gitTreeCompare.showCheckedInTree",
+                    "when": "view == gitTreeCompare && config.gitTreeCompare.showCheckboxes && gitTreeCompare.hideCheckedFiles",
+                    "group": "navigation@0"
+                },
+                {
+                    "command": "gitTreeCompare.viewAsList",
+                    "when": "view == gitTreeCompare && !gitTreeCompare.viewAsList",
+                    "group": "navigation@1"
+                },
+                {
+                    "command": "gitTreeCompare.viewAsTree",
+                    "when": "view == gitTreeCompare && gitTreeCompare.viewAsList",
+                    "group": "navigation@1"
+                },
+                {
+                    "command": "gitTreeCompare.searchChanges",
+                    "when": "view == gitTreeCompare && (!config.gitTreeCompare.multiRepositoryView || gitOpenRepositoryCount == 1)",
+                    "group": "2_files"
+                },
+                {
+                    "command": "gitTreeCompare.filterFiles",
+                    "when": "view == gitTreeCompare && (!config.gitTreeCompare.multiRepositoryView || gitOpenRepositoryCount == 1)",
+                    "group": "navigation@4"
+                },
+                {
+                    "command": "gitTreeCompare.clearFilter",
+                    "when": "view == gitTreeCompare && (!config.gitTreeCompare.multiRepositoryView || gitOpenRepositoryCount == 1) && gitTreeCompare.isFiltered",
+                    "group": "navigation@5"
+                },
+                {
+                    "command": "gitTreeCompare.collapseAll",
+                    "when": "view == gitTreeCompare",
+                    "group": "navigation@6"
+                },
+                {
+                    "submenu": "gitTreeCompare.viewAndSort",
+                    "when": "view == gitTreeCompare",
+                    "group": "0_view_and_sort"
+                }
+            ],
+            "view/item/context": [
+                {
+                    "command": "gitTreeCompare.changeBase",
+                    "when": "view == gitTreeCompare && viewItem == repo && config.gitTreeCompare.multiRepositoryView",
+                    "group": "inline@1"
+                },
+                {
+                    "command": "gitTreeCompare.openAllChanges",
+                    "when": "view == gitTreeCompare && viewItem == repo && config.gitTreeCompare.multiRepositoryView",
+                    "group": "inline@2"
+                },
+                {
+                    "command": "gitTreeCompare.openChangedFiles",
+                    "when": "view == gitTreeCompare && viewItem == repo && config.gitTreeCompare.multiRepositoryView",
+                    "group": "inline@3"
+                },
+                {
+                    "command": "gitTreeCompare.refresh",
+                    "when": "view == gitTreeCompare && viewItem == repo && config.gitTreeCompare.multiRepositoryView",
+                    "group": "inline@4"
+                },
+                {
+                    "command": "gitTreeCompare.filterFiles",
+                    "when": "view == gitTreeCompare && viewItem == repo && config.gitTreeCompare.multiRepositoryView",
+                    "group": "inline@5"
+                },
+                {
+                    "command": "gitTreeCompare.discardAllChanges",
+                    "when": "view == gitTreeCompare && viewItem == repo && config.gitTreeCompare.multiRepositoryView"
+                },
+                {
+                    "command": "gitTreeCompare.compareGitHubPullRequest",
+                    "when": "view == gitTreeCompare && viewItem == repo && config.gitTreeCompare.multiRepositoryView"
+                },
+                {
+                    "command": "gitTreeCompare.searchChanges",
+                    "when": "view == gitTreeCompare && viewItem == repo && config.gitTreeCompare.multiRepositoryView"
+                },
+                {
+                    "command": "gitTreeCompare.clearFilter",
+                    "when": "view == gitTreeCompare && viewItem == repo && config.gitTreeCompare.multiRepositoryView && gitTreeCompare.isFiltered"
+                },
+                {
+                    "command": "gitTreeCompare.openChanges",
+                    "when": "view == gitTreeCompare && viewItem == file && !config.gitTreeCompare.openChanges",
+                    "group": "inline"
+                },
+                {
+                    "command": "gitTreeCompare.openFile",
+                    "when": "view == gitTreeCompare && viewItem == file && config.gitTreeCompare.openChanges",
+                    "group": "inline"
+                },
+                {
+                    "command": "gitTreeCompare.discardChanges",
+                    "when": "view == gitTreeCompare && viewItem == file",
+                    "group": "inline"
+                },
+                {
+                    "command": "gitTreeCompare.discardChanges",
+                    "when": "view == gitTreeCompare && viewItem == folder",
+                    "group": "inline"
+                },
+                {
+                    "command": "gitTreeCompare.discardAllChanges",
+                    "when": "view == gitTreeCompare && viewItem == ref",
+                    "group": "inline"
+                },
+                {
+                    "command": "gitTreeCompare.openChanges",
+                    "when": "view == gitTreeCompare && viewItem == file && !config.gitTreeCompare.openChanges",
+                    "group": "1_open"
+                },
+                {
+                    "command": "gitTreeCompare.openFile",
+                    "when": "view == gitTreeCompare && viewItem == file && config.gitTreeCompare.openChanges",
+                    "group": "1_open"
+                },
+                {
+                    "command": "gitTreeCompare.discardChanges",
+                    "when": "view == gitTreeCompare && viewItem == file",
+                    "group": "2_discard"
+                },
+                {
+                    "command": "gitTreeCompare.discardChanges",
+                    "when": "view == gitTreeCompare && viewItem == folder",
+                    "group": "2_discard"
+                },
+                {
+                    "command": "gitTreeCompare.discardAllChanges",
+                    "when": "view == gitTreeCompare && viewItem == ref"
+                },
+                {
+                    "command": "gitTreeCompare.changeBase",
+                    "when": "view == gitTreeCompare && viewItem == ref"
+                },
+                {
+                    "command": "gitTreeCompare.changeBase",
+                    "when": "view == gitTreeCompare && viewItem == ref",
+                    "group": "inline"
+                },
+                {
+                    "command": "gitTreeCompare.openAllChanges",
+                    "when": "view == gitTreeCompare && viewItem == ref"
+                },
+                {
+                    "command": "gitTreeCompare.openAllChanges",
+                    "when": "view == gitTreeCompare && viewItem == folder"
+                },
+                {
+                    "command": "gitTreeCompare.openChangedFiles",
+                    "when": "view == gitTreeCompare && viewItem == ref"
+                },
+                {
+                    "command": "gitTreeCompare.openChangedFiles",
+                    "when": "view == gitTreeCompare && viewItem == folder"
+                },
+                {
+                    "command": "gitTreeCompare.openAllChanges",
+                    "when": "view == gitTreeCompare && viewItem == ref",
+                    "group": "inline"
+                },
+                {
+                    "command": "gitTreeCompare.openAllChanges",
+                    "when": "view == gitTreeCompare && viewItem == folder",
+                    "group": "inline"
+                },
+                {
+                    "command": "gitTreeCompare.openChangedFiles",
+                    "when": "view == gitTreeCompare && viewItem == ref",
+                    "group": "inline"
+                },
+                {
+                    "command": "gitTreeCompare.openChangedFiles",
+                    "when": "view == gitTreeCompare && viewItem == folder",
+                    "group": "inline"
+                },
+                {
+                    "command": "gitTreeCompare.switchToFullDiff",
+                    "when": "view == gitTreeCompare && viewItem == ref && config.gitTreeCompare.diffMode == merge"
+                },
+                {
+                    "command": "gitTreeCompare.switchToMergeDiff",
+                    "when": "view == gitTreeCompare && viewItem == ref && config.gitTreeCompare.diffMode == full"
+                },
+                {
+                    "command": "gitTreeCompare.copyPath",
+                    "when": "view == gitTreeCompare && viewItem == file",
+                    "group": "3_copy"
+                },
+                {
+                    "command": "gitTreeCompare.copyRelativePath",
+                    "when": "view == gitTreeCompare && viewItem == file",
+                    "group": "3_copy"
+                },
+                {
+                    "submenu": "gitTreeCompare.viewAndSort",
+                    "when": "view == gitTreeCompare && (viewItem == ref || (viewItem == repo && config.gitTreeCompare.multiRepositoryView))",
+                    "group": "0_view_and_sort"
+                },
+                {
+                    "command": "gitTreeCompare.openChangesWithDifftool",
+                    "when": "view == gitTreeCompare && viewItem == file && config.gitTreeCompare.openChangesWithDifftool",
+                    "group": "1_open"
+                }
+            ]
+        },
+        "configuration": {
+            "title": "Git Tree Compare",
+            "properties": {
+                "gitTreeCompare.autoChangeRepository": {
+                    "type": "boolean",
+                    "description": "[EXPERIMENTAL] Whether to change the active repository whenever a different one is selected in the SCM view. Note that this only works well when not selecting multiple repositories. See GitHub issue #70 for more details.",
+                    "default": false
+                },
+                "gitTreeCompare.multiRepositoryView": {
+                    "type": "boolean",
+                    "description": "[EXPERIMENTAL] Whether to show one expandable Git Tree Compare section per open repository instead of selecting a single active repository.",
+                    "default": false
+                },
+                "gitTreeCompare.autoRefresh": {
+                    "type": "boolean",
+                    "description": "Whether to refresh the tree whenever a file in the workspace changes.",
+                    "default": true
+                },
+                "gitTreeCompare.refreshIndex": {
+                    "type": "boolean",
+                    "description": "Whether to refresh the git index each time the tree is refreshed. This avoids superfluous diff entries for cases when only the file modification date is changed, at the cost of an extra git invocation.",
+                    "default": true
+                },
+                "gitTreeCompare.findRenames": {
+                    "type": "boolean",
+                    "description": "Whether to detect renames. Does not affect untracked files. May have a performance impact.",
+                    "default": true
+                },
+                "gitTreeCompare.renameThreshold": {
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 100,
+                    "description": "The similarity index (in percent) for rename detection. A value of 100 means that only identical files are detected as renames, a value of 0 means that any file with any similarity is detected as a rename. Has no effect if gitTreeCompare.findRenames is false.",
+                    "default": 50
+                },
+                "gitTreeCompare.openChanges": {
+                    "type": "boolean",
+                    "description": "When selecting a modified file in the tree, whether to show its changes or just open the workspace file.",
+                    "default": true
+                },
+                "gitTreeCompare.root": {
+                    "type": "string",
+                    "enum": [
+                        "workspace",
+                        "repository"
+                    ],
+                    "description": "The root of the tree when the workspace folder is not the same as the repository root.",
+                    "default": "workspace"
+                },
+                "gitTreeCompare.includeFilesOutsideWorkspaceRoot": {
+                    "type": "boolean",
+                    "description": "If gitTreeCompare.root is \"workspace\", whether to display files which are within the repository but outside the workspace folder in a special \"/\" folder.",
+                    "default": true
+                },
+                "gitTreeCompare.diffMode": {
+                    "type": "string",
+                    "enum": [
+                        "merge",
+                        "full"
+                    ],
+                    "description": "Whether to compare against the selected base ref directly (full mode) or by computing a merge base first (merge mode).",
+                    "default": "merge"
+                },
+                "gitTreeCompare.iconsMinimal": {
+                    "type": "boolean",
+                    "description": "Whether to use a compact icon alignment (like Seti file icon theme) where only files have icons.",
+                    "default": false
+                },
+                "gitTreeCompare.iconStyle": {
+                    "type": "string",
+                    "description": "Which icon style to use for files in the compare tree.",
+                    "enum": [
+                        "status",
+                        "fileTheme"
+                    ],
+                    "enumDescriptions": [
+                        "Use the extension's git status icons for files.",
+                        "Use VS Code file theme icons and color file labels by git status."
+                    ],
+                    "default": "status"
+                },
+                "gitTreeCompare.collapsed": {
+                    "type": "boolean",
+                    "description": "Whether to show folders collapsed instead of expanded. NOTE: A restart is required when changing this setting.",
+                    "default": false
+                },
+                "gitTreeCompare.compactFolders": {
+                    "type": "boolean",
+                    "description": "Whether to compact (flatten) single-child folders into a single tree element. Useful for Java package structures, for example. May have a performance impact for large diff trees.",
+                    "default": true
+                },
+                "gitTreeCompare.showCheckboxes": {
+                    "type": "boolean",
+                    "description": "Whether to show checkboxes such that files or folders can be ticked off, for example when reviewing.",
+                    "default": false
+                },
+                "gitTreeCompare.resetCheckboxOnFileChange": {
+                    "type": "boolean",
+                    "description": "When enabled, automatically resets checkboxes when a file is modified after being checked. This ensures that checked files reflect their reviewed state, and any subsequent modifications require re-review.",
+                    "default": false
+                },
+                "gitTreeCompare.refSortOrder": {
+                    "type": "string",
+                    "enum": [
+                        "alphabetically",
+                        "committerdate"
+                    ],
+                    "description": "How to sort refs (branches, tags) when changing the comparison base. 'committerdate' sorts by most recently committed first.",
+                    "default": "committerdate"
+                },
+                "gitTreeCompare.omitUntrackedFiles": {
+                    "type": "boolean",
+                    "description": "Whether to omit untracked files from the diff. When enabled, files that are not tracked by git will not appear in the tree.",
+                    "default": false
+                },
+                "gitTreeCompare.omitUnstagedChanges": {
+                    "type": "boolean",
+                    "description": "Whether to omit unstaged changes from the diff. When enabled, only staged changes will appear in the tree.",
+                    "default": false
+                },
+                "gitTreeCompare.sortOrder": {
+                    "type": "string",
+                    "enum": [
+                        "name",
+                        "path",
+                        "status",
+                        "recentlyModified"
+                    ],
+                    "description": "How to sort files when viewing as list. Only applies in list view mode. 'name' sorts by file name, 'path' sorts by full path, 'status' sorts by git status, 'recentlyModified' sorts by modification date with most recent first.",
+                    "default": "path"
+                },
+                "gitTreeCompare.autoReveal": {
+                    "type": "boolean",
+                    "description": "Whether to automatically reveal and select the tree item corresponding to the currently active editor.",
+                    "default": true
+                },
+                "gitTreeCompare.openChangesWithDifftool": {
+                    "type": "boolean",
+                    "description": "Whether to show the 'Open Changes with Difftool' command in the context menu for files. This command opens the changes in the external diff tool configured in Git (e.g., via 'git config diff.tool').",
+                    "default": false
+                },
+                "gitTreeCompare.showDiffStats": {
+                    "type": "boolean",
+                    "description": "Whether to show insertion/deletion counts (+N -N) next to each file.",
+                    "default": false
+                }
+            }
+        }
+    },
+    "scripts": {
+        "vscode:prepublish": "webpack --mode production",
+        "compile": "webpack --mode none",
+        "watch": "webpack --mode none --watch --env development",
+        "test-compile": "tsc -p ./"
+    },
+    "devDependencies": {
+        "@types/byline": "4.2.31",
+        "@types/file-type": "^5.2.1",
+        "@types/node": "^13.5.0",
+        "@types/vscode": "^1.81.0",
+        "@types/which": "^1.0.28",
+        "@vscode/vsce": "^2.20.1",
+        "ts-loader": "^9.2.6",
+        "typescript": "^4.4.3",
+        "webpack": "^5.44.0",
+        "webpack-cli": "^4.2.0"
+    },
+    "dependencies": {
+        "@octokit/rest": "^22.0.1",
+        "@vscode/iconv-lite-umd": "0.7.0",
+        "byline": "^5.0.0",
+        "file-type": "^7.2.0",
+        "jschardet": "3.0.0",
+        "vscode-nls": "^4.0.0",
+        "which": "^1.3.0"
     }
-  },
-  "scripts": {
-    "vscode:prepublish": "webpack --mode production",
-    "compile": "webpack --mode none",
-    "watch": "webpack --mode none --watch --env development",
-    "test-compile": "tsc -p ./"
-  },
-  "devDependencies": {
-    "@types/byline": "4.2.31",
-    "@types/file-type": "^5.2.1",
-    "@types/node": "^13.5.0",
-    "@types/vscode": "^1.81.0",
-    "@types/which": "^1.0.28",
-    "@vscode/vsce": "^2.20.1",
-    "ts-loader": "^9.2.6",
-    "typescript": "^4.4.3",
-    "webpack": "^5.44.0",
-    "webpack-cli": "^4.2.0"
-  },
-  "dependencies": {
-    "@octokit/rest": "^22.0.1",
-    "@vscode/iconv-lite-umd": "0.7.0",
-    "byline": "^5.0.0",
-    "file-type": "^7.2.0",
-    "jschardet": "3.0.0",
-    "vscode-nls": "^4.0.0",
-    "which": "^1.3.0"
-  }
 }

--- a/package.json
+++ b/package.json
@@ -276,37 +276,37 @@
             "view/title": [
                 {
                     "command": "gitTreeCompare.changeRepository",
-                    "when": "view == gitTreeCompare && !config.gitTreeCompare.multiRepositoryView && gitOpenRepositoryCount != 1",
+                    "when": "view == gitTreeCompare && !gitTreeCompare.showRepositoryNodes && gitOpenRepositoryCount != 1",
                     "group": "1_state"
                 },
                 {
                     "command": "gitTreeCompare.changeRepository",
-                    "when": "view == gitTreeCompare && !config.gitTreeCompare.multiRepositoryView && gitOpenRepositoryCount != 1",
+                    "when": "view == gitTreeCompare && !gitTreeCompare.showRepositoryNodes && gitOpenRepositoryCount != 1",
                     "group": "navigation@2"
                 },
                 {
                     "command": "gitTreeCompare.changeBase",
-                    "when": "view == gitTreeCompare && (!config.gitTreeCompare.multiRepositoryView || gitOpenRepositoryCount == 1)",
+                    "when": "view == gitTreeCompare && !gitTreeCompare.showRepositoryNodes",
                     "group": "1_state"
                 },
                 {
                     "command": "gitTreeCompare.compareGitHubPullRequest",
-                    "when": "view == gitTreeCompare && (!config.gitTreeCompare.multiRepositoryView || gitOpenRepositoryCount == 1)",
+                    "when": "view == gitTreeCompare && !gitTreeCompare.showRepositoryNodes",
                     "group": "1_state"
                 },
                 {
                     "command": "gitTreeCompare.openAllChanges",
-                    "when": "view == gitTreeCompare && (!config.gitTreeCompare.multiRepositoryView || gitOpenRepositoryCount == 1)",
+                    "when": "view == gitTreeCompare && !gitTreeCompare.showRepositoryNodes",
                     "group": "2_files"
                 },
                 {
                     "command": "gitTreeCompare.openChangedFiles",
-                    "when": "view == gitTreeCompare && (!config.gitTreeCompare.multiRepositoryView || gitOpenRepositoryCount == 1)",
+                    "when": "view == gitTreeCompare && !gitTreeCompare.showRepositoryNodes",
                     "group": "2_files"
                 },
                 {
                     "command": "gitTreeCompare.discardAllChanges",
-                    "when": "view == gitTreeCompare && (!config.gitTreeCompare.multiRepositoryView || gitOpenRepositoryCount == 1)",
+                    "when": "view == gitTreeCompare && !gitTreeCompare.showRepositoryNodes",
                     "group": "2_files"
                 },
                 {
@@ -361,17 +361,17 @@
                 },
                 {
                     "command": "gitTreeCompare.searchChanges",
-                    "when": "view == gitTreeCompare && (!config.gitTreeCompare.multiRepositoryView || gitOpenRepositoryCount == 1)",
+                    "when": "view == gitTreeCompare && !gitTreeCompare.showRepositoryNodes",
                     "group": "2_files"
                 },
                 {
                     "command": "gitTreeCompare.filterFiles",
-                    "when": "view == gitTreeCompare && (!config.gitTreeCompare.multiRepositoryView || gitOpenRepositoryCount == 1)",
+                    "when": "view == gitTreeCompare && !gitTreeCompare.showRepositoryNodes",
                     "group": "navigation@4"
                 },
                 {
                     "command": "gitTreeCompare.clearFilter",
-                    "when": "view == gitTreeCompare && (!config.gitTreeCompare.multiRepositoryView || gitOpenRepositoryCount == 1) && gitTreeCompare.isFiltered",
+                    "when": "view == gitTreeCompare && !gitTreeCompare.showRepositoryNodes && gitTreeCompare.isFiltered",
                     "group": "navigation@5"
                 },
                 {
@@ -388,44 +388,44 @@
             "view/item/context": [
                 {
                     "command": "gitTreeCompare.changeBase",
-                    "when": "view == gitTreeCompare && viewItem == repo && config.gitTreeCompare.multiRepositoryView",
+                    "when": "view == gitTreeCompare && viewItem == repo",
                     "group": "inline@1"
                 },
                 {
                     "command": "gitTreeCompare.openAllChanges",
-                    "when": "view == gitTreeCompare && viewItem == repo && config.gitTreeCompare.multiRepositoryView",
+                    "when": "view == gitTreeCompare && viewItem == repo",
                     "group": "inline@2"
                 },
                 {
                     "command": "gitTreeCompare.openChangedFiles",
-                    "when": "view == gitTreeCompare && viewItem == repo && config.gitTreeCompare.multiRepositoryView",
+                    "when": "view == gitTreeCompare && viewItem == repo",
                     "group": "inline@3"
                 },
                 {
                     "command": "gitTreeCompare.refresh",
-                    "when": "view == gitTreeCompare && viewItem == repo && config.gitTreeCompare.multiRepositoryView",
+                    "when": "view == gitTreeCompare && viewItem == repo",
                     "group": "inline@4"
                 },
                 {
                     "command": "gitTreeCompare.filterFiles",
-                    "when": "view == gitTreeCompare && viewItem == repo && config.gitTreeCompare.multiRepositoryView",
+                    "when": "view == gitTreeCompare && viewItem == repo",
                     "group": "inline@5"
                 },
                 {
                     "command": "gitTreeCompare.discardAllChanges",
-                    "when": "view == gitTreeCompare && viewItem == repo && config.gitTreeCompare.multiRepositoryView"
+                    "when": "view == gitTreeCompare && viewItem == repo"
                 },
                 {
                     "command": "gitTreeCompare.compareGitHubPullRequest",
-                    "when": "view == gitTreeCompare && viewItem == repo && config.gitTreeCompare.multiRepositoryView"
+                    "when": "view == gitTreeCompare && viewItem == repo"
                 },
                 {
                     "command": "gitTreeCompare.searchChanges",
-                    "when": "view == gitTreeCompare && viewItem == repo && config.gitTreeCompare.multiRepositoryView"
+                    "when": "view == gitTreeCompare && viewItem == repo"
                 },
                 {
                     "command": "gitTreeCompare.clearFilter",
-                    "when": "view == gitTreeCompare && viewItem == repo && config.gitTreeCompare.multiRepositoryView && gitTreeCompare.isFiltered"
+                    "when": "view == gitTreeCompare && viewItem == repo && gitTreeCompare.isFiltered"
                 },
                 {
                     "command": "gitTreeCompare.openChanges",
@@ -475,6 +475,10 @@
                 {
                     "command": "gitTreeCompare.discardAllChanges",
                     "when": "view == gitTreeCompare && viewItem == ref"
+                },
+                {
+                    "command": "gitTreeCompare.changeRepository",
+                    "when": "view == gitTreeCompare && viewItem == ref && !gitTreeCompare.showRepositoryNodes && gitOpenRepositoryCount != 1"
                 },
                 {
                     "command": "gitTreeCompare.changeBase",
@@ -541,7 +545,7 @@
                 },
                 {
                     "submenu": "gitTreeCompare.viewAndSort",
-                    "when": "view == gitTreeCompare && (viewItem == ref || (viewItem == repo && config.gitTreeCompare.multiRepositoryView))",
+                    "when": "view == gitTreeCompare && (viewItem == ref || viewItem == repo)",
                     "group": "0_view_and_sort"
                 },
                 {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -70,6 +70,11 @@ export function activate(context: ExtensionContext) {
             provider!.manualRefresh(node);
         });
     });
+    commands.registerCommand(NAMESPACE + '.refreshAll', () => {
+        runAfterInit(() => {
+            provider!.manualRefreshAll();
+        });
+    });
     commands.registerCommand(NAMESPACE + '.openAllChanges', node => {
         runAfterInit(() => provider!.openAllChanges(node));
     });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -44,9 +44,9 @@ export function activate(context: ExtensionContext) {
         });
     });
 
-    commands.registerCommand(NAMESPACE + '.discardAllChanges', () => {
+    commands.registerCommand(NAMESPACE + '.discardAllChanges', node => {
         runAfterInit(() => {
-            provider!.discardAllChanges();
+            provider!.discardAllChanges(node);
         });
     });
 
@@ -55,19 +55,19 @@ export function activate(context: ExtensionContext) {
             provider!.promptChangeRepository();
         });
     });
-    commands.registerCommand(NAMESPACE + '.changeBase', () => {
+    commands.registerCommand(NAMESPACE + '.changeBase', node => {
         runAfterInit(() => {
-            provider!.promptChangeBase();
+            provider!.promptChangeBase(node);
         });
     });
-    commands.registerCommand(NAMESPACE + '.compareGitHubPullRequest', () => {
+    commands.registerCommand(NAMESPACE + '.compareGitHubPullRequest', node => {
         runAfterInit(() => {
-            provider!.compareGitHubPullRequest();
+            provider!.compareGitHubPullRequest(node);
         });
     });
-    commands.registerCommand(NAMESPACE + '.refresh', () => {
+    commands.registerCommand(NAMESPACE + '.refresh', node => {
         runAfterInit(() => {
-            provider!.manualRefresh();
+            provider!.manualRefresh(node);
         });
     });
     commands.registerCommand(NAMESPACE + '.openAllChanges', node => {
@@ -94,14 +94,14 @@ export function activate(context: ExtensionContext) {
     commands.registerCommand(NAMESPACE + '.viewAsTree', () => {
         runAfterInit(() => provider!.viewAsTree(true));
     });
-    commands.registerCommand(NAMESPACE + '.searchChanges', () => {
-        runAfterInit(() => provider!.searchChanges());
+    commands.registerCommand(NAMESPACE + '.searchChanges', node => {
+        runAfterInit(() => provider!.searchChanges(node));
     });
-    commands.registerCommand(NAMESPACE + '.filterFiles', () => {
-        runAfterInit(() => provider!.filterFiles());
+    commands.registerCommand(NAMESPACE + '.filterFiles', node => {
+        runAfterInit(() => provider!.filterFiles(node));
     });
-    commands.registerCommand(NAMESPACE + '.clearFilter', () => {
-        runAfterInit(() => provider!.clearFilter());
+    commands.registerCommand(NAMESPACE + '.clearFilter', node => {
+        runAfterInit(() => provider!.clearFilter(node));
     });
     commands.registerCommand(NAMESPACE + '.copyPath', node => {
         runAfterInit(() => provider!.copyPath(node));

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -149,6 +149,7 @@ export function activate(context: ExtensionContext) {
         commands.executeCommand('setContext', NAMESPACE + '.viewAsList', false);
         commands.executeCommand('setContext', NAMESPACE + '.hideCheckedFiles', false);
         commands.executeCommand('setContext', NAMESPACE + '.isFiltered', false);
+        commands.executeCommand('setContext', NAMESPACE + '.showRepositoryNodes', false);
 
         provider = new GitTreeCompareProvider(git, gitApi, outputChannel, context.globalState, context.asAbsolutePath);
 
@@ -160,6 +161,10 @@ export function activate(context: ExtensionContext) {
             }
         );
 
-        provider.init(treeView);
+        disposables.push(provider, treeView);
+        void provider.init(treeView).catch(error => {
+            outputChannel.appendLine(`Initializing Git Tree Compare failed: ${error.message}`);
+            window.showErrorMessage(`Initializing Git Tree Compare failed: ${error.message}`);
+        });
     });
 }

--- a/src/treeProvider.ts
+++ b/src/treeProvider.ts
@@ -47,7 +47,8 @@ class FileElement implements IDiffStatus {
         public dstAbsPath: string,
         public dstRelPath: string,
         public status: StatusCode,
-        public isSubmodule: boolean) {}
+        public isSubmodule: boolean,
+        public repositoryRoot: string) {}
 
     get label(): string {
         return path.basename(this.dstAbsPath)
@@ -58,21 +59,44 @@ class FolderElement {
     constructor(
         public label: string,
         public dstAbsPath: string,
-        public useFilesOutsideTreeRoot: boolean) {}
+        public useFilesOutsideTreeRoot: boolean,
+        public repositoryRoot: string) {}
 }
 
 class RepoRootElement extends FolderElement {
-    constructor(absPath: string) {
-        super('/', absPath, true);
+    constructor(repositoryRoot: string, absPath: string) {
+        super('/', absPath, true, repositoryRoot);
     }
+}
+
+class RepositoryElement {
+    constructor(public repositoryRoot: string, public label: string, public hasChildren: boolean) {}
 }
 
 class RefElement {
     constructor(public repositoryRoot: string, public refName: string, public hasChildren: boolean) {}
 }
 
-export type Element = FileElement | FolderElement | RepoRootElement | RefElement
+export type Element = FileElement | FolderElement | RepoRootElement | RepositoryElement | RefElement
 type FileSystemElement = FileElement | FolderElement
+
+interface RepositoryState {
+    repository: Repository | undefined;
+    baseRef: string;
+    workspaceFolder: string;
+    absGitDir: string;
+    repoRoot: FolderAbsPath;
+    headLastChecked: Date;
+    headName: string | undefined;
+    headCommit: string;
+    mergeBase: string;
+    filesInsideTreeRoot: Map<FolderAbsPath, IDiffStatus[]>;
+    filesOutsideTreeRoot: Map<FolderAbsPath, IDiffStatus[]>;
+    treeRoot: FolderAbsPath;
+    isPaused: boolean;
+    checkboxStates: Map<string, CheckboxStateInfo>;
+    searchFilter: string | undefined;
+}
 
 class ChangeBaseRefItem implements QuickPickItem {
 	protected get shortCommit(): string { return (this.ref.commit || '').substr(0, 8); }
@@ -145,6 +169,9 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
     private baseRef: string;
     private viewAsList = false;
     private searchFilter: string | undefined;
+    private repositoryStates: Map<string, RepositoryState> = new Map();
+    private repositoryRootAliases: Map<string, string> = new Map();
+    private activeRepoRoot: string | undefined;
 
     // Static state of repository
     private workspaceFolder: string;
@@ -181,14 +208,120 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
         this.readConfig();
     }
 
+    private captureRepositoryState(): RepositoryState | undefined {
+        if (!this.activeRepoRoot || !this.repository) {
+            return;
+        }
+        return {
+            repository: this.repository,
+            baseRef: this.baseRef,
+            workspaceFolder: this.workspaceFolder,
+            absGitDir: this.absGitDir,
+            repoRoot: this.repoRoot,
+            headLastChecked: this.headLastChecked,
+            headName: this.headName,
+            headCommit: this.headCommit,
+            mergeBase: this.mergeBase,
+            filesInsideTreeRoot: this.filesInsideTreeRoot,
+            filesOutsideTreeRoot: this.filesOutsideTreeRoot,
+            treeRoot: this.treeRoot,
+            isPaused: this.isPaused,
+            checkboxStates: this.checkboxStates,
+            searchFilter: this.searchFilter,
+        };
+    }
+
+    private saveRepositoryState() {
+        const state = this.captureRepositoryState();
+        if (state) {
+            this.repositoryStates.set(state.repoRoot, state);
+        }
+    }
+
+    private loadRepositoryState(repositoryRoot: string): boolean {
+        const repoRoot = this.resolveRepositoryRootAlias(repositoryRoot);
+        const state = this.repositoryStates.get(repoRoot);
+        if (!state) {
+            return false;
+        }
+        this.repository = state.repository;
+        this.baseRef = state.baseRef;
+        this.workspaceFolder = state.workspaceFolder;
+        this.absGitDir = state.absGitDir;
+        this.repoRoot = state.repoRoot;
+        this.headLastChecked = state.headLastChecked;
+        this.headName = state.headName;
+        this.headCommit = state.headCommit;
+        this.mergeBase = state.mergeBase;
+        this.filesInsideTreeRoot = state.filesInsideTreeRoot;
+        this.filesOutsideTreeRoot = state.filesOutsideTreeRoot;
+        this.treeRoot = state.treeRoot;
+        this.isPaused = state.isPaused;
+        this.checkboxStates = state.checkboxStates;
+        this.searchFilter = state.searchFilter;
+        this.activeRepoRoot = state.repoRoot;
+        return true;
+    }
+
+    private async useRepository(repositoryRoot: string): Promise<boolean> {
+        const repoRoot = this.resolveRepositoryRootAlias(repositoryRoot);
+        if (this.activeRepoRoot === repoRoot && this.repository) {
+            return true;
+        }
+        this.saveRepositoryState();
+        if (this.loadRepositoryState(repoRoot)) {
+            return true;
+        }
+        await this.setRepository(repoRoot);
+        return true;
+    }
+
+    private async hydrateRepository(repositoryRoot: string): Promise<boolean> {
+        try {
+            const hadState = this.repositoryStates.has(this.resolveRepositoryRootAlias(repositoryRoot));
+            await this.useRepository(repositoryRoot);
+            if (!hadState || !this.baseRef) {
+                await this.updateRefs();
+            }
+            if (!hadState) {
+                await this.updateDiff(false);
+            }
+            this.saveRepositoryState();
+            return true;
+        } catch (e: any) {
+            this.log(`Ignoring repository ${repositoryRoot}`, e);
+            return false;
+        }
+    }
+
+    private getCurrentRepositoryRoots(selectedFirst=false): string[] {
+        const roots = getGitRepositoryFolders(this.gitApi, selectedFirst).map(normalizePath);
+        if (workspace.workspaceFolders) {
+            roots.push(...workspace.workspaceFolders.map(folder => normalizePath(folder.uri.fsPath)));
+        }
+        const uniqueRoots: string[] = [];
+        const seen = new Set<string>();
+        for (const root of roots) {
+            const resolvedRoot = this.resolveRepositoryRootAlias(root);
+            if (!seen.has(resolvedRoot)) {
+                uniqueRoots.push(root);
+                seen.add(resolvedRoot);
+            }
+        }
+        return uniqueRoots;
+    }
+
+    private resolveRepositoryRootAlias(repositoryRoot: string): string {
+        const normalized = normalizePath(repositoryRoot);
+        return this.repositoryRootAliases.get(normalized) ?? normalized;
+    }
+
+    private getRepositoryRootFromElement(element: Element | undefined): string | undefined {
+        return element?.repositoryRoot;
+    }
+
     async init(treeView: TreeView<Element>) {
         this.treeView = treeView
-
-        // use arbitrary repository at start if there are multiple (prefer selected ones)
-        const gitRepos = getGitRepositoryFolders(this.gitApi, true);
-        if (gitRepos.length > 0) {
-            await this.changeRepository(gitRepos[0]);
-        }
 
         this.disposables.push(workspace.onDidChangeConfiguration(this.handleConfigChange, this));
         this.disposables.push(workspace.onDidChangeWorkspaceFolders(this.handleWorkspaceFoldersChanged, this));
@@ -228,10 +361,15 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
     }
 
     async setRepository(repositoryRoot: string) {
-        const dotGit = await this.git.getRepositoryDotGit(repositoryRoot);
-        const repository = this.git.open(repositoryRoot, dotGit);
+        this.saveRepositoryState();
+        const requestedRepositoryRoot = normalizePath(repositoryRoot);
+        const actualRepositoryRoot = normalizePath(await this.git.getRepositoryRoot(requestedRepositoryRoot));
+        const dotGit = await this.git.getRepositoryDotGit(actualRepositoryRoot);
+        const repository = this.git.open(actualRepositoryRoot, dotGit);
         const absGitDir = await getAbsGitDir(repository);
         const repoRoot = normalizePath(repository.root);
+        this.repositoryRootAliases.set(requestedRepositoryRoot, repoRoot);
+        this.repositoryRootAliases.set(repoRoot, repoRoot);
 
         const workspaceFolders = getWorkspaceFolders(repoRoot);
         if (workspaceFolders.length == 0) {
@@ -241,6 +379,17 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
         this.repository = repository;
         this.absGitDir = absGitDir;
         this.repoRoot = repoRoot;
+        this.activeRepoRoot = repoRoot;
+        this.baseRef = '';
+        this.mergeBase = '';
+        this.headLastChecked = new Date(0);
+        this.headName = undefined;
+        this.headCommit = '';
+        this.filesInsideTreeRoot = new Map();
+        this.filesOutsideTreeRoot = new Map();
+        this.checkboxStates = new Map();
+        this.searchFilter = undefined;
+        this.isPaused = false;
 
         // Sort descending by folder depth
         workspaceFolders.sort((a, b) => {
@@ -258,8 +407,31 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
     }
 
     private updateTreeTitle() {
-        if (!this.repository) {
+        const repoCount = this.getCurrentRepositoryRoots().length;
+        if (repoCount === 0) {
             this.treeView.title = 'none';
+            return;
+        }
+        if (repoCount === 1 && this.repository) {
+            const repoName = path.basename(this.repoRoot);
+            if (this.searchFilter) {
+                this.treeView.title = `${repoName} (filtered)`;
+            } else {
+                this.treeView.title = repoName;
+            }
+            return;
+        }
+        const hasFilter = [...this.repositoryStates.values()].some(state => state.searchFilter);
+        if (hasFilter) {
+            this.treeView.title = `Git Tree Compare (filtered)`;
+        } else {
+            this.treeView.title = 'Git Tree Compare';
+        }
+    }
+
+    private updateTreeTitleForCurrentRepository() {
+        if (!this.repository || this.getCurrentRepositoryRoots().length !== 1) {
+            this.updateTreeTitle();
             return;
         }
         const repoName = path.basename(this.repoRoot);
@@ -272,6 +444,8 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
 
     async unsetRepository() {
         this.repository = undefined;
+        this.activeRepoRoot = undefined;
+        this.repositoryStates.clear();
         this.fireTreeDataChange();
         this.log('No repository selected');
 
@@ -283,6 +457,7 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
             await this.setRepository(repositoryRoot);
             await this.updateRefs();
             await this.updateDiff(false);
+            this.saveRepositoryState();
         } catch (e: any) {
             let msg = 'Changing the repository failed';
             this.log(msg, e);
@@ -292,6 +467,7 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
         this.checkboxStates.clear();
         this.searchFilter = undefined;
         this.updateFilterContext();
+        this.saveRepositoryState();
         this.fireTreeDataChange();
     }
 
@@ -310,9 +486,7 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
     }
 
     private async handleRepositoryOpened(repository: GitAPIRepository) {
-        if (this.repository === undefined) {
-            await this.changeRepository(repository.rootUri.fsPath);
-        }
+        this.fireTreeDataChange();
         this.disposables.push(repository.ui.onDidChange(() => this.handleRepositoryUiChange(repository)));
     }
 
@@ -334,36 +508,32 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
 
     private async handleWorkspaceFoldersChanged(e: WorkspaceFoldersChangeEvent) {
         // If the folder got removed that was currently active in the diff,
-        // then pick an arbitrary new one.
+        // clear its cached state and let the tree render the remaining roots.
         for (var removedFolder of e.removed) {
             if (normalizePath(removedFolder.uri.fsPath) === this.workspaceFolder) {
-                const gitRepos = getGitRepositoryFolders(this.gitApi, true);
+                const gitRepos = this.getCurrentRepositoryRoots(true);
                 if (gitRepos.length > 0) {
-                    const newFolder = gitRepos[0];
-                    await this.changeRepository(newFolder);
+                    this.repositoryStates.delete(normalizePath(removedFolder.uri.fsPath));
+                    this.fireTreeDataChange();
                 } else {
                     await this.unsetRepository();
                 }
             }
         }
-        // If no repository is selected but new folders were added,
-        // then pick an arbitrary new one.
         if (!this.repository && e.added) {
-            const gitRepos = getGitRepositoryFolders(this.gitApi, true);
-            if (gitRepos.length > 0) {
-                const newFolder = gitRepos[0];
-                await this.changeRepository(newFolder);
-            }
+            this.fireTreeDataChange();
         }
     }
 
     private async handleChangeCheckboxState(e: TreeCheckboxChangeEvent<Element>) {
         for (let [element, state] of e.items) {
             if (element instanceof FileElement || element instanceof FolderElement) {
+                this.loadRepositoryState(element.repositoryRoot);
                 this.checkboxStates.set(element.dstAbsPath, {
                     state: state,
                     timestamp: Date.now()
                 });
+                this.saveRepositoryState();
             }
         }
     }
@@ -456,6 +626,7 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
     }
 
     getTreeItem(element: Element): TreeItem {
+        this.loadRepositoryState(element.repositoryRoot);
         let checkboxState: TreeItemCheckboxState | undefined;
         if (this.showCheckboxes) {
             if (element instanceof FileElement) {
@@ -475,6 +646,7 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
     }
 
     private computeFolderCheckboxState(folder: FolderElement): TreeItemCheckboxState {
+        this.loadRepositoryState(folder.repositoryRoot);
         // Check if user explicitly set state on this folder
         const explicitState = this.checkboxStates.get(folder.dstAbsPath);
         if (explicitState) {
@@ -506,34 +678,35 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
 
     async getChildren(element?: Element): Promise<Element[]> {
         if (!element) {
-            if (!this.repository) {
+            const gitRepos = this.getCurrentRepositoryRoots(true);
+            this.updateTreeTitle();
+            return gitRepos.map(repositoryRoot =>
+                new RepositoryElement(repositoryRoot, path.basename(repositoryRoot), true));
+        } else if (element instanceof RepositoryElement) {
+            if (!await this.hydrateRepository(element.repositoryRoot)) {
                 return [];
-            }
-            if (!this.filesInsideTreeRoot) {
-                try {
-                    await this.updateDiff(false);
-                } catch (e: any) {
-                    // some error occured, ignore and try again next time
-                    this.log('Ignoring updateDiff() error during initial getChildren()', e);
-                    return [];
-                }
             }
             const hasFiles =
                 this.filesInsideTreeRoot.size > 0 ||
                 (this.includeFilesOutsideWorkspaceFolderRoot && this.filesOutsideTreeRoot.size > 0);
-
-                const children = [new RefElement(this.repoRoot, this.baseRef, hasFiles)];
-                // RefElement is the root, no parent to record
-                return children;
+            const children = [new RefElement(this.repoRoot, this.baseRef, hasFiles)];
+            this.recordParents(element, children);
+            return children;
         } else if (element instanceof RefElement) {
+            if (!await this.hydrateRepository(element.repositoryRoot)) {
+                return [];
+            }
             const entries: Element[] = [];
             if (this.includeFilesOutsideWorkspaceFolderRoot && this.filesOutsideTreeRoot.size > 0) {
-                entries.push(new RepoRootElement(this.repoRoot));
+                entries.push(new RepoRootElement(this.repoRoot, this.repoRoot));
             }
             const children = entries.concat(this.getFileSystemEntries(this.treeRoot, false));
             this.recordParents(element, children);
             return children;
         } else if (element instanceof FolderElement) {
+            if (!await this.hydrateRepository(element.repositoryRoot)) {
+                return [];
+            }
             const children = this.getFileSystemEntries(element.dstAbsPath, element.useFilesOutsideTreeRoot);
             this.recordParents(element, children);
             return children;
@@ -826,12 +999,17 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
 
     @debounce(2000)
     private async handleWorkspaceChange(uri: Uri) {
-        if (!this.autoRefresh || !this.repository) {
+        if (!this.autoRefresh) {
             return
+        }
+        const normPath = normalizePath(uri.fsPath);
+        const repoRoot = this.findRepositoryRootForPath(normPath);
+        if (!repoRoot || !await this.useRepository(repoRoot)) {
+            this.log(`Ignoring change outside of repositories: ${uri.fsPath}`)
+            return;
         }
         // ignore changes outside of repo root
         //  e.g. "c:\Users\..\AppData\Roaming\Code - Insiders\User\globalStorage"
-        const normPath = normalizePath(uri.fsPath);
         if (!normPath.startsWith(this.repoRoot + path.sep)) {
             this.log(`Ignoring change outside of repository: ${uri.fsPath}`)
             return
@@ -862,6 +1040,7 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
         }
         try {
             await this.updateDiff(true);
+            this.saveRepositoryState();
         } catch (e: any) {
             // some error occured, ignore and try again next time
             this.log('Ignoring updateDiff() error during handleWorkspaceChange()', e);
@@ -900,34 +1079,37 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
             oldOmitUnstagedChanges != this.omitUnstagedChanges ||
             oldSortOrder != this.sortOrder) {
 
-            if (!this.repository) {
-                return;
-            }
-
-            const oldTreeRoot = this.treeRoot;
-            if (oldTreeRootIsRepo != this.treeRootIsRepo) {
-                this.updateTreeRootFolder();
-            }
-
-            if (oldFullDiff != this.fullDiff ||
-                oldFindRenames != this.findRenames ||
-                oldRenameThreshold != this.renameThreshold ||
-                oldTreeRoot != this.treeRoot ||
-                (!oldAutoRefresh && this.autoRefresh) ||
-                (!oldRefreshIndex && this.refreshIndex) ||
-                oldOmitUntrackedFiles != this.omitUntrackedFiles ||
-                oldOmitUnstagedChanges != this.omitUnstagedChanges) {
-                try {
-                    await this.updateRefs(this.baseRef);
-                    await this.updateDiff(false);
-                } catch (e: any) {
-                    let msg = 'Updating the git tree failed';
-                    this.log(msg, e);
-                    window.showErrorMessage(`${msg}: ${e.message}`);
-                    // clear the tree as it would be confusing to display stale data under the new settings
-                    this.filesInsideTreeRoot = new Map();
-                    this.filesOutsideTreeRoot = new Map();
+            for (const repositoryRoot of this.getCurrentRepositoryRoots(true)) {
+                if (!await this.hydrateRepository(repositoryRoot)) {
+                    continue;
                 }
+
+                const oldTreeRoot = this.treeRoot;
+                if (oldTreeRootIsRepo != this.treeRootIsRepo) {
+                    this.updateTreeRootFolder();
+                }
+
+                if (oldFullDiff != this.fullDiff ||
+                    oldFindRenames != this.findRenames ||
+                    oldRenameThreshold != this.renameThreshold ||
+                    oldTreeRoot != this.treeRoot ||
+                    (!oldAutoRefresh && this.autoRefresh) ||
+                    (!oldRefreshIndex && this.refreshIndex) ||
+                    oldOmitUntrackedFiles != this.omitUntrackedFiles ||
+                    oldOmitUnstagedChanges != this.omitUnstagedChanges) {
+                    try {
+                        await this.updateRefs(this.baseRef);
+                        await this.updateDiff(false);
+                    } catch (e: any) {
+                        let msg = 'Updating the git tree failed';
+                        this.log(msg, e);
+                        window.showErrorMessage(`${msg}: ${e.message}`);
+                        // clear the tree as it would be confusing to display stale data under the new settings
+                        this.filesInsideTreeRoot = new Map();
+                        this.filesOutsideTreeRoot = new Map();
+                    }
+                }
+                this.saveRepositoryState();
             }
             this.fireTreeDataChange();
         }
@@ -983,7 +1165,7 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
                 for (const file of fileEntries) {
                     if (this.matchesFilter(file.dstAbsPath, relPathBase)) {
                         const dstRelPath = path.relative(relPathBase, file.dstAbsPath);
-                        entries.push(new FileElement(file.srcAbsPath, file.dstAbsPath, dstRelPath, file.status, file.isSubmodule));
+                        entries.push(new FileElement(file.srcAbsPath, file.dstAbsPath, dstRelPath, file.status, file.isSubmodule, this.repoRoot));
                     }
                 }
             }
@@ -1020,7 +1202,7 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
 
                     const label = path.relative(folder, compactedPath);
                     entries.push(new FolderElement(
-                        label, compactedPath, useFilesOutsideTreeRoot));
+                        label, compactedPath, useFilesOutsideTreeRoot, this.repoRoot));
                 }
             }
             entries.sort((a, b) => a.label.split(path.sep, 1)[0].localeCompare(b.label.split(path.sep, 1)[0]));
@@ -1031,7 +1213,7 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
                     if (this.folderHasMatchingFiles(folder2, useFilesOutsideTreeRoot)) {
                         const label = path.basename(folder2);
                         entries.push(new FolderElement(
-                            label, folder2, useFilesOutsideTreeRoot));
+                            label, folder2, useFilesOutsideTreeRoot, this.repoRoot));
                     }
                 }
             }
@@ -1046,7 +1228,7 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
             for (const file of fileEntries) {
                 if (this.matchesFilter(file.dstAbsPath, relPathBase)) {
                     const dstRelPath = path.relative(relPathBase, file.dstAbsPath);
-                    entries.push(new FileElement(file.srcAbsPath, file.dstAbsPath, dstRelPath, file.status, file.isSubmodule));
+                    entries.push(new FileElement(file.srcAbsPath, file.dstAbsPath, dstRelPath, file.status, file.isSubmodule, this.repoRoot));
                 }
             }
         }
@@ -1115,6 +1297,7 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
 
     private getDiffStatus(fileEntry?: FileElement): IDiffStatus | undefined {
         if (fileEntry) {
+            this.loadRepositoryState(fileEntry.repositoryRoot);
             return fileEntry;
         }
         const uri = window.activeTextEditor && window.activeTextEditor.document.uri;
@@ -1122,11 +1305,23 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
             return;
         }
         const dstAbsPath = uri.fsPath;
+        const repoRoot = this.findRepositoryRootForPath(dstAbsPath);
+        if (repoRoot) {
+            this.loadRepositoryState(repoRoot);
+        }
         const folder = path.dirname(dstAbsPath);
         const isInsideTreeRoot = folder === this.treeRoot || folder.startsWith(this.treeRoot + path.sep);
         const files = isInsideTreeRoot ? this.filesInsideTreeRoot : this.filesOutsideTreeRoot;
         const diffStatus = files.get(folder)?.find(file => file.dstAbsPath === dstAbsPath);
         return diffStatus;
+    }
+
+    private findRepositoryRootForPath(absPath: string): string | undefined {
+        const normPath = normalizePath(absPath);
+        const repoRoots = this.getCurrentRepositoryRoots()
+            .filter(repoRoot => normPath === repoRoot || normPath.startsWith(repoRoot + path.sep))
+            .sort((a, b) => b.length - a.length);
+        return repoRoots[0];
     }
 
     async openChanges(fileEntry?: FileElement) {
@@ -1156,7 +1351,11 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
             left, right, filename + " (Working Tree)", options);
     }
 
-    openAllChanges(entry: RefElement | RepoRootElement | FolderElement | undefined) {
+    openAllChanges(entry: RefElement | RepoRootElement | FolderElement | RepositoryElement | undefined) {
+        const repositoryRoot = this.getRepositoryRootFromElement(entry);
+        if (repositoryRoot) {
+            this.loadRepositoryState(repositoryRoot);
+        }
         const withinFolder = entry instanceof FolderElement ? entry.dstAbsPath : undefined;
         for (const file of this.iterFiles(withinFolder)) {
             this.doOpenChanges(file.srcAbsPath, file.dstAbsPath, file.status, false);
@@ -1183,10 +1382,16 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
     }
 
     async discardChanges(entries: (FileElement | FolderElement)[]) {
-        let statuses: IDiffStatus[] = [];
+        const statusesByRepository = new Map<string, IDiffStatus[]>();
         for (const entry of entries) {
+            this.loadRepositoryState(entry.repositoryRoot);
+            let statuses = statusesByRepository.get(entry.repositoryRoot);
+            if (!statuses) {
+                statuses = [];
+                statusesByRepository.set(entry.repositoryRoot, statuses);
+            }
             if (entry instanceof FolderElement) {
-                statuses = statuses.concat([...this.iterFiles(entry.dstAbsPath)]);
+                statuses.push(...this.iterFiles(entry.dstAbsPath));
             } else {
                 const diffStatus = this.getDiffStatus(entry);
                 if (diffStatus) {
@@ -1194,10 +1399,17 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
                 }
             }
         }
-        await this.doDiscardChanges(statuses);
+        for (const [repositoryRoot, statuses] of statusesByRepository) {
+            this.loadRepositoryState(repositoryRoot);
+            await this.doDiscardChanges(statuses);
+        }
     }
 
-    async discardAllChanges() {
+    async discardAllChanges(entry?: RefElement | RepositoryElement) {
+        const repositoryRoot = this.getRepositoryRootFromElement(entry);
+        if (repositoryRoot) {
+            this.loadRepositoryState(repositoryRoot);
+        }
         const statuses = [...this.iterFiles()];
         await this.doDiscardChanges(statuses);
     }
@@ -1308,7 +1520,11 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
         }
     }
 
-    openChangedFiles(entry: RefElement | RepoRootElement | FolderElement | undefined) {
+    openChangedFiles(entry: RefElement | RepoRootElement | FolderElement | RepositoryElement | undefined) {
+        const repositoryRoot = this.getRepositoryRootFromElement(entry);
+        if (repositoryRoot) {
+            this.loadRepositoryState(repositoryRoot);
+        }
         const withinFolder = entry instanceof FolderElement ? entry.dstAbsPath : undefined;
         for (const file of this.iterFiles(withinFolder)) {
             if (file.status == 'D') {
@@ -1333,7 +1549,11 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
         }
     }
 
-    async promptChangeBase() {
+    async promptChangeBase(entry?: RefElement | RepositoryElement) {
+        const repositoryRoot = this.getRepositoryRootFromElement(entry);
+        if (repositoryRoot) {
+            await this.useRepository(repositoryRoot);
+        }
         if (!this.repository) {
             window.showErrorMessage('No repository selected');
             return;
@@ -1384,6 +1604,7 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
             }
             try {
                 await this.updateDiff(false);
+                this.saveRepositoryState();
             } catch (e: any) {
                 let msg = 'Updating the git tree failed';
                 this.log(msg, e);
@@ -1391,13 +1612,18 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
                 // clear the tree as it would be confusing to display the old tree under the new base
                 this.filesInsideTreeRoot = new Map();
                 this.filesOutsideTreeRoot = new Map();
+                this.saveRepositoryState();
             }
             this.log('Refreshing tree');
             this.fireTreeDataChange();
         });
     }
 
-    async compareGitHubPullRequest() {
+    async compareGitHubPullRequest(entry?: RefElement | RepositoryElement) {
+        const repositoryRoot = this.getRepositoryRootFromElement(entry);
+        if (repositoryRoot) {
+            await this.useRepository(repositoryRoot);
+        }
         if (!this.repository) {
             window.showErrorMessage('No repository selected');
             return;
@@ -1567,6 +1793,7 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
                     this.log(`Updating base to: ${originBaseRef}`);
                     await this.updateRefs(originBaseRef);
                     await this.updateDiff(false);
+                    this.saveRepositoryState();
                     this.log('Refreshing tree');
                     this.fireTreeDataChange();
                     window.showInformationMessage(`Now comparing PR #${prNumber}: ${pr.title}`);
@@ -1584,7 +1811,11 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
         });
     }
 
-    async manualRefresh() {
+    async manualRefresh(entry?: RefElement | RepositoryElement) {
+        const repositoryRoot = this.getRepositoryRootFromElement(entry);
+        if (repositoryRoot) {
+            await this.useRepository(repositoryRoot);
+        }
         window.withProgress({ location: ProgressLocation.Window, title: 'Updating Tree' }, async _ => {
             try {
                 if (await this.isHeadChanged()) {
@@ -1592,6 +1823,7 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
                     await this.updateRefs(this.baseRef);
                 }
                 await this.updateDiff(true);
+                this.saveRepositoryState();
             } catch (e: any) {
                 let msg = 'Updating the git tree failed';
                 this.log(msg, e);
@@ -1645,7 +1877,11 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
         await config.update('sortOrder', 'recentlyModified', true);
     }
 
-    async searchChanges() {
+    async searchChanges(entry?: RefElement | RepositoryElement) {
+        const repositoryRoot = this.getRepositoryRootFromElement(entry);
+        if (repositoryRoot) {
+            this.loadRepositoryState(repositoryRoot);
+        }
         const uris = [...this.iterFiles()].map(file => Uri.file(file.dstAbsPath));
         const relativePaths = uris.map(uri => path.relative(this.repoRoot, uri.fsPath));
         await commands.executeCommand('workbench.action.findInFiles', {
@@ -1655,7 +1891,11 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
         });
     }
 
-    async filterFiles() {
+    async filterFiles(entry?: RefElement | RepositoryElement) {
+        const repositoryRoot = this.getRepositoryRootFromElement(entry);
+        if (repositoryRoot) {
+            this.loadRepositoryState(repositoryRoot);
+        }
         const searchTerm = await window.showInputBox({
             prompt: 'Enter text to filter files (leave empty to show all)',
             placeHolder: 'Filter by filename or path...',
@@ -1667,25 +1907,32 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
         }
 
         this.searchFilter = searchTerm.trim() || undefined;
-        this.updateTreeTitle();
+        this.saveRepositoryState();
+        this.updateTreeTitleForCurrentRepository();
         this.updateFilterContext();
         this.log(this.searchFilter ? `Filtering files by: ${this.searchFilter}` : 'Cleared file filter');
         this.fireTreeDataChange();
     }
 
-    clearFilter() {
+    clearFilter(entry?: RefElement | RepositoryElement) {
+        const repositoryRoot = this.getRepositoryRootFromElement(entry);
+        if (repositoryRoot) {
+            this.loadRepositoryState(repositoryRoot);
+        }
         if (!this.searchFilter) {
             return;
         }
         this.searchFilter = undefined;
-        this.updateTreeTitle();
+        this.saveRepositoryState();
+        this.updateTreeTitleForCurrentRepository();
         this.updateFilterContext();
         this.log('Cleared file filter');
         this.fireTreeDataChange();
     }
 
     private updateFilterContext() {
-        commands.executeCommand('setContext', NAMESPACE + '.isFiltered', !!this.searchFilter);
+        const isFiltered = !!this.searchFilter || [...this.repositoryStates.values()].some(state => state.searchFilter);
+        commands.executeCommand('setContext', NAMESPACE + '.isFiltered', isFiltered);
     }
 
     async copyPath(fileEntry: FileElement) {
@@ -1763,12 +2010,16 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
 }
 
 function getElementId(element: Element): string {
+    const repositoryRoot = element.repositoryRoot;
+    if (element instanceof RepositoryElement) {
+        return `repo:${repositoryRoot}`;
+    }
     if (element instanceof RefElement) {
-        return 'ref';
+        return `ref:${repositoryRoot}`;
     } else if (element instanceof RepoRootElement) {
-        return 'root';
+        return `root:${repositoryRoot}`;
     } else {
-        return element.dstAbsPath;
+        return `${repositoryRoot}:${element.dstAbsPath}`;
     }
 }
 
@@ -1791,7 +2042,7 @@ function toTreeItem(element: Element, openChangesOnSelect: boolean, iconsMinimal
             }
         }
         item.contextValue = element.isSubmodule ? 'submodule' : 'file';
-        item.id = element.dstAbsPath;
+        item.id = getElementId(element);
         item.iconPath = path.join(gitIconRoot,	toIconName(element) + '.svg');
         if (checkboxState !== undefined) {
             item.checkboxState = checkboxState;
@@ -1809,16 +2060,26 @@ function toTreeItem(element: Element, openChangesOnSelect: boolean, iconsMinimal
         const item = new TreeItem(element.label, TreeItemCollapsibleState.Collapsed);
         item.tooltip = element.dstAbsPath;
         item.contextValue = 'root';
-        item.id = 'root'
+        item.id = getElementId(element);
         if (!iconsMinimal) {
             item.iconPath = new ThemeIcon('folder-opened');
+        }
+        return item;
+    } else if (element instanceof RepositoryElement) {
+        const state = element.hasChildren ? TreeItemCollapsibleState.Collapsed : TreeItemCollapsibleState.None;
+        const item = new TreeItem(element.label, state);
+        item.tooltip = element.repositoryRoot;
+        item.contextValue = 'repo';
+        item.id = getElementId(element);
+        if (!iconsMinimal) {
+            item.iconPath = new ThemeIcon('repo');
         }
         return item;
     } else if (element instanceof FolderElement) {
         const item = new TreeItem(element.label, showCollapsed ? TreeItemCollapsibleState.Collapsed : TreeItemCollapsibleState.Expanded);
         item.tooltip = element.dstAbsPath;
         item.contextValue = 'folder';
-        item.id = element.dstAbsPath;
+        item.id = getElementId(element);
         if (checkboxState !== undefined) {
             item.checkboxState = checkboxState;
         }
@@ -1832,7 +2093,7 @@ function toTreeItem(element: Element, openChangesOnSelect: boolean, iconsMinimal
         const item = new TreeItem(label, state);
         item.tooltip = `${element.refName} (${path.basename(element.repositoryRoot)})`;
         item.contextValue = 'ref';
-        item.id = 'ref'
+        item.id = getElementId(element);
         if (!iconsMinimal) {
             item.iconPath = new ThemeIcon('git-compare');
         }

--- a/src/treeProvider.ts
+++ b/src/treeProvider.ts
@@ -2041,8 +2041,13 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
         if (!await this.ensureRepositoryForCommand(entry)) {
             return;
         }
-        const uris = [...this.iterFiles()].map(file => Uri.file(file.dstAbsPath));
-        const relativePaths = uris.map(uri => path.relative(this.repoRoot, uri.fsPath));
+        const relativePaths = [...this.iterFiles()]
+            .map(file => path.relative(this.workspaceFolder, file.dstAbsPath))
+            .filter(relPath => relPath && !relPath.startsWith('..' + path.sep) && relPath !== '..');
+        if (relativePaths.length === 0) {
+            window.showInformationMessage('No changed files to search.');
+            return;
+        }
         await commands.executeCommand('workbench.action.findInFiles', {
             query: '',
             filesToInclude: relativePaths.join(','),

--- a/src/treeProvider.ts
+++ b/src/treeProvider.ts
@@ -1952,10 +1952,17 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
     }
 
     async manualRefresh(entry?: RefElement | RepositoryElement) {
-        const repositoryRoot = this.getRepositoryRootFromElement(entry);
-        const repositoryRoots = repositoryRoot
-            ? [repositoryRoot]
-            : (this.multiRepositoryView ? this.getCurrentRepositoryRoots(true) : []);
+        if (!await this.ensureRepositoryForCommand(entry)) {
+            window.showErrorMessage('No repository selected');
+            return;
+        }
+        window.withProgress({ location: ProgressLocation.Window, title: 'Updating Tree' }, async _ => {
+            await this.refreshActiveRepository();
+        });
+    }
+
+    async manualRefreshAll() {
+        const repositoryRoots = this.multiRepositoryView ? this.getCurrentRepositoryRoots(true) : [];
         if (repositoryRoots.length > 1) {
             window.withProgress({ location: ProgressLocation.Window, title: 'Updating Tree' }, async _ => {
                 for (const repoRoot of repositoryRoots) {
@@ -1968,7 +1975,7 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
             });
             return;
         }
-        if (!await this.ensureRepositoryForCommand(entry)) {
+        if (!await this.ensureRepositoryForCommand(undefined)) {
             window.showErrorMessage('No repository selected');
             return;
         }

--- a/src/treeProvider.ts
+++ b/src/treeProvider.ts
@@ -14,7 +14,7 @@ import { getDefaultBranch, getHeadModificationDate, getBranchCommit,
          diffIndex, IDiffStatus, StatusCode, getAbsGitDir,
          getWorkspaceFolders, getGitRepositoryFolders, hasUncommittedChanges, rmFile } from './gitHelper'
 import { tryDeepenForMergeBase } from './deepenHelper'
-import { debounce, throttle } from './git/decorators'
+import { throttle } from './git/decorators'
 import { normalizePath } from './fsUtils';
 import { API as GitAPI, Repository as GitAPIRepository } from './typings/git';
 import { Octokit } from '@octokit/rest';
@@ -149,6 +149,7 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
     private includeFilesOutsideWorkspaceFolderRoot: boolean;
     private openChangesOnSelect: boolean;
     private autoChangeRepository: boolean;
+    private multiRepositoryView: boolean;
     private autoRefresh: boolean;
     private refreshIndex: boolean;
     private iconsMinimal: boolean;
@@ -199,6 +200,8 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
     private checkboxStates: Map<string, CheckboxStateInfo> = new Map<string, CheckboxStateInfo>();
     private parentMap: Map<string, Element> = new Map();
     private elementMap: Map<string, FileElement> = new Map();
+    private pendingRefreshRepositories = new Map<string, Uri>();
+    private pendingRefreshTimer: NodeJS.Timeout | undefined;
 
     // Other
     private readonly disposables: Disposable[] = [];
@@ -296,9 +299,6 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
 
     private getCurrentRepositoryRoots(selectedFirst=false): string[] {
         const roots = getGitRepositoryFolders(this.gitApi, selectedFirst).map(normalizePath);
-        if (workspace.workspaceFolders) {
-            roots.push(...workspace.workspaceFolders.map(folder => normalizePath(folder.uri.fsPath)));
-        }
         const uniqueRoots: string[] = [];
         const seen = new Set<string>();
         for (const root of roots) {
@@ -320,8 +320,32 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
         return element?.repositoryRoot;
     }
 
+    private async ensureRepositoryForCommand(element: Element | undefined): Promise<boolean> {
+        const repositoryRoot = this.getRepositoryRootFromElement(element);
+        if (repositoryRoot) {
+            return await this.hydrateRepository(repositoryRoot);
+        }
+        if (this.repository) {
+            return true;
+        }
+        const gitRepos = this.getCurrentRepositoryRoots(true);
+        if (gitRepos.length === 1) {
+            return await this.hydrateRepository(gitRepos[0]);
+        }
+        return false;
+    }
+
     async init(treeView: TreeView<Element>) {
         this.treeView = treeView
+
+        // Use the original single-repository behavior unless multi-repo view
+        // actually has multiple repositories to display.
+        const gitRepos = this.getCurrentRepositoryRoots(true);
+        if (!this.multiRepositoryView || gitRepos.length === 1) {
+            if (gitRepos.length > 0) {
+                await this.changeRepository(gitRepos[0]);
+            }
+        }
 
         this.disposables.push(workspace.onDidChangeConfiguration(this.handleConfigChange, this));
         this.disposables.push(workspace.onDidChangeWorkspaceFolders(this.handleWorkspaceFoldersChanged, this));
@@ -358,6 +382,11 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
 
         this.disposables.push(treeView.onDidChangeCheckboxState(this.handleChangeCheckboxState, this));
         this.disposables.push(window.onDidChangeActiveTextEditor(this.handleActiveEditorChange, this));
+        this.disposables.push(new Disposable(() => {
+            if (this.pendingRefreshTimer) {
+                clearTimeout(this.pendingRefreshTimer);
+            }
+        }));
     }
 
     async setRepository(repositoryRoot: string) {
@@ -407,6 +436,19 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
     }
 
     private updateTreeTitle() {
+        if (!this.multiRepositoryView) {
+            if (!this.repository) {
+                this.treeView.title = 'none';
+                return;
+            }
+            const repoName = path.basename(this.repoRoot);
+            if (this.searchFilter) {
+                this.treeView.title = `${repoName} (filtered)`;
+            } else {
+                this.treeView.title = repoName;
+            }
+            return;
+        }
         const repoCount = this.getCurrentRepositoryRoots().length;
         if (repoCount === 0) {
             this.treeView.title = 'none';
@@ -486,6 +528,10 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
     }
 
     private async handleRepositoryOpened(repository: GitAPIRepository) {
+        const gitRepos = this.getCurrentRepositoryRoots(true);
+        if ((!this.multiRepositoryView || gitRepos.length === 1) && this.repository === undefined) {
+            await this.changeRepository(repository.rootUri.fsPath);
+        }
         this.fireTreeDataChange();
         this.disposables.push(repository.ui.onDidChange(() => this.handleRepositoryUiChange(repository)));
     }
@@ -507,20 +553,50 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
     }
 
     private async handleWorkspaceFoldersChanged(e: WorkspaceFoldersChangeEvent) {
-        // If the folder got removed that was currently active in the diff,
-        // clear its cached state and let the tree render the remaining roots.
-        for (var removedFolder of e.removed) {
-            if (normalizePath(removedFolder.uri.fsPath) === this.workspaceFolder) {
-                const gitRepos = this.getCurrentRepositoryRoots(true);
-                if (gitRepos.length > 0) {
-                    this.repositoryStates.delete(normalizePath(removedFolder.uri.fsPath));
-                    this.fireTreeDataChange();
-                } else {
-                    await this.unsetRepository();
+        if (!this.multiRepositoryView) {
+            // If the folder got removed that was currently active in the diff,
+            // then pick an arbitrary new one.
+            for (var removedFolder of e.removed) {
+                if (normalizePath(removedFolder.uri.fsPath) === this.workspaceFolder) {
+                    const gitRepos = this.getCurrentRepositoryRoots(true);
+                    if (gitRepos.length > 0) {
+                        const newFolder = gitRepos[0];
+                        await this.changeRepository(newFolder);
+                    } else {
+                        await this.unsetRepository();
+                    }
                 }
             }
+            // If no repository is selected but new folders were added,
+            // then pick an arbitrary new one.
+            if (!this.repository && e.added) {
+                const gitRepos = this.getCurrentRepositoryRoots(true);
+                if (gitRepos.length > 0) {
+                    const newFolder = gitRepos[0];
+                    await this.changeRepository(newFolder);
+                }
+            }
+            return;
         }
-        if (!this.repository && e.added) {
+
+        let removedAnyRepository = e.removed.length > 0;
+        for (var removedFolder of e.removed) {
+            const removedRoot = normalizePath(removedFolder.uri.fsPath);
+            const resolvedRoot = this.resolveRepositoryRootAlias(removedRoot);
+            this.repositoryStates.delete(resolvedRoot);
+            this.repositoryRootAliases.delete(removedRoot);
+            this.repositoryRootAliases.delete(resolvedRoot);
+            if (resolvedRoot === this.activeRepoRoot) {
+                this.repository = undefined;
+                this.activeRepoRoot = undefined;
+            }
+        }
+        const gitRepos = this.getCurrentRepositoryRoots(true);
+        if (gitRepos.length === 0) {
+            await this.unsetRepository();
+            return;
+        }
+        if (removedAnyRepository || e.added.length > 0) {
             this.fireTreeDataChange();
         }
     }
@@ -577,6 +653,7 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
         this.includeFilesOutsideWorkspaceFolderRoot = config.get<boolean>('includeFilesOutsideWorkspaceRoot', true);
         this.openChangesOnSelect = config.get<boolean>('openChanges', true);
         this.autoChangeRepository = config.get<boolean>('autoChangeRepository', false);
+        this.multiRepositoryView = config.get<boolean>('multiRepositoryView', false);
         this.autoRefresh = config.get<boolean>('autoRefresh', true);
         this.refreshIndex = config.get<boolean>('refreshIndex', true);
         this.iconsMinimal = config.get<boolean>('iconsMinimal', false);
@@ -680,8 +757,29 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
         if (!element) {
             const gitRepos = this.getCurrentRepositoryRoots(true);
             this.updateTreeTitle();
-            return gitRepos.map(repositoryRoot =>
-                new RepositoryElement(repositoryRoot, path.basename(repositoryRoot), true));
+            if (this.multiRepositoryView && gitRepos.length > 1) {
+                return gitRepos.map(repositoryRoot =>
+                    new RepositoryElement(repositoryRoot, path.basename(repositoryRoot), true));
+            }
+            if (!this.repository) {
+                return [];
+            }
+            if (!this.filesInsideTreeRoot) {
+                try {
+                    await this.updateDiff(false);
+                } catch (e: any) {
+                    // some error occured, ignore and try again next time
+                    this.log('Ignoring updateDiff() error during initial getChildren()', e);
+                    return [];
+                }
+            }
+            const hasFiles =
+                this.filesInsideTreeRoot.size > 0 ||
+                (this.includeFilesOutsideWorkspaceFolderRoot && this.filesOutsideTreeRoot.size > 0);
+
+            const children = [new RefElement(this.repoRoot, this.baseRef, hasFiles)];
+            // RefElement is the root, no parent to record
+            return children;
         } else if (element instanceof RepositoryElement) {
             if (!await this.hydrateRepository(element.repositoryRoot)) {
                 return [];
@@ -997,14 +1095,37 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
         return false;
     }
 
-    @debounce(2000)
-    private async handleWorkspaceChange(uri: Uri) {
+    private handleWorkspaceChange(uri: Uri) {
         if (!this.autoRefresh) {
             return
         }
         const normPath = normalizePath(uri.fsPath);
         const repoRoot = this.findRepositoryRootForPath(normPath);
-        if (!repoRoot || !await this.useRepository(repoRoot)) {
+        if (!repoRoot) {
+            this.log(`Ignoring change outside of repositories: ${uri.fsPath}`)
+            return;
+        }
+        this.pendingRefreshRepositories.set(repoRoot, uri);
+        if (this.pendingRefreshTimer) {
+            clearTimeout(this.pendingRefreshTimer);
+        }
+        this.pendingRefreshTimer = setTimeout(() => {
+            this.pendingRefreshTimer = undefined;
+            this.refreshPendingRepositories();
+        }, 2000);
+    }
+
+    private async refreshPendingRepositories() {
+        const repositoryEntries = [...this.pendingRefreshRepositories.entries()];
+        this.pendingRefreshRepositories.clear();
+        for (const [repoRoot, uri] of repositoryEntries) {
+            await this.refreshRepositoryForWorkspaceChange(repoRoot, uri);
+        }
+    }
+
+    private async refreshRepositoryForWorkspaceChange(repoRoot: string, uri: Uri) {
+        const normPath = normalizePath(uri.fsPath);
+        if (!await this.useRepository(repoRoot)) {
             this.log(`Ignoring change outside of repositories: ${uri.fsPath}`)
             return;
         }
@@ -1024,7 +1145,7 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
             const onDidFocusWindowOrBecomeVisible = anyEvent<any>(onDidFocusWindow, onDidBecomeVisible);
             await eventToPromise(onDidFocusWindowOrBecomeVisible);
             this.isPaused = false;
-            this.handleWorkspaceChange(uri);
+            await this.refreshRepositoryForWorkspaceChange(repoRoot, uri);
             return;
         }
         this.log(`Relevant workspace change detected: ${uri.fsPath}`)
@@ -1063,10 +1184,12 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
         const oldOmitUntrackedFiles = this.omitUntrackedFiles;
         const oldOmitUnstagedChanges = this.omitUnstagedChanges;
         const oldSortOrder = this.sortOrder;
+        const oldMultiRepositoryView = this.multiRepositoryView;
         this.readConfig();
         if (oldTreeRootIsRepo != this.treeRootIsRepo ||
             oldInclude != this.includeFilesOutsideWorkspaceFolderRoot ||
             oldOpenChangesOnSelect != this.openChangesOnSelect ||
+            oldMultiRepositoryView != this.multiRepositoryView ||
             oldIconsMinimal != this.iconsMinimal ||
             (!oldAutoRefresh && this.autoRefresh) ||
             (!oldRefreshIndex && this.refreshIndex) ||
@@ -1079,7 +1202,27 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
             oldOmitUnstagedChanges != this.omitUnstagedChanges ||
             oldSortOrder != this.sortOrder) {
 
-            for (const repositoryRoot of this.getCurrentRepositoryRoots(true)) {
+            if (oldMultiRepositoryView != this.multiRepositoryView) {
+                this.repositoryStates.clear();
+                this.repositoryRootAliases.clear();
+                const gitRepos = this.getCurrentRepositoryRoots(true);
+                if (!this.multiRepositoryView || gitRepos.length === 1) {
+                    if (gitRepos.length > 0) {
+                        await this.changeRepository(gitRepos[0]);
+                    } else {
+                        await this.unsetRepository();
+                    }
+                    return;
+                }
+                this.fireTreeDataChange();
+                return;
+            }
+
+            const repositoriesToUpdate = this.multiRepositoryView
+                ? this.getCurrentRepositoryRoots(true)
+                : (this.repository ? [this.repoRoot] : []);
+
+            for (const repositoryRoot of repositoriesToUpdate) {
                 if (!await this.hydrateRepository(repositoryRoot)) {
                     continue;
                 }
@@ -1351,10 +1494,9 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
             left, right, filename + " (Working Tree)", options);
     }
 
-    openAllChanges(entry: RefElement | RepoRootElement | FolderElement | RepositoryElement | undefined) {
-        const repositoryRoot = this.getRepositoryRootFromElement(entry);
-        if (repositoryRoot) {
-            this.loadRepositoryState(repositoryRoot);
+    async openAllChanges(entry: RefElement | RepoRootElement | FolderElement | RepositoryElement | undefined) {
+        if (!await this.ensureRepositoryForCommand(entry)) {
+            return;
         }
         const withinFolder = entry instanceof FolderElement ? entry.dstAbsPath : undefined;
         for (const file of this.iterFiles(withinFolder)) {
@@ -1406,9 +1548,8 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
     }
 
     async discardAllChanges(entry?: RefElement | RepositoryElement) {
-        const repositoryRoot = this.getRepositoryRootFromElement(entry);
-        if (repositoryRoot) {
-            this.loadRepositoryState(repositoryRoot);
+        if (!await this.ensureRepositoryForCommand(entry)) {
+            return;
         }
         const statuses = [...this.iterFiles()];
         await this.doDiscardChanges(statuses);
@@ -1520,10 +1661,9 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
         }
     }
 
-    openChangedFiles(entry: RefElement | RepoRootElement | FolderElement | RepositoryElement | undefined) {
-        const repositoryRoot = this.getRepositoryRootFromElement(entry);
-        if (repositoryRoot) {
-            this.loadRepositoryState(repositoryRoot);
+    async openChangedFiles(entry: RefElement | RepoRootElement | FolderElement | RepositoryElement | undefined) {
+        if (!await this.ensureRepositoryForCommand(entry)) {
+            return;
         }
         const withinFolder = entry instanceof FolderElement ? entry.dstAbsPath : undefined;
         for (const file of this.iterFiles(withinFolder)) {
@@ -1550,9 +1690,9 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
     }
 
     async promptChangeBase(entry?: RefElement | RepositoryElement) {
-        const repositoryRoot = this.getRepositoryRootFromElement(entry);
-        if (repositoryRoot) {
-            await this.useRepository(repositoryRoot);
+        if (!await this.ensureRepositoryForCommand(entry)) {
+            window.showErrorMessage('No repository selected');
+            return;
         }
         if (!this.repository) {
             window.showErrorMessage('No repository selected');
@@ -1620,9 +1760,9 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
     }
 
     async compareGitHubPullRequest(entry?: RefElement | RepositoryElement) {
-        const repositoryRoot = this.getRepositoryRootFromElement(entry);
-        if (repositoryRoot) {
-            await this.useRepository(repositoryRoot);
+        if (!await this.ensureRepositoryForCommand(entry)) {
+            window.showErrorMessage('No repository selected');
+            return;
         }
         if (!this.repository) {
             window.showErrorMessage('No repository selected');
@@ -1813,23 +1953,43 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
 
     async manualRefresh(entry?: RefElement | RepositoryElement) {
         const repositoryRoot = this.getRepositoryRootFromElement(entry);
-        if (repositoryRoot) {
-            await this.useRepository(repositoryRoot);
+        const repositoryRoots = repositoryRoot
+            ? [repositoryRoot]
+            : (this.multiRepositoryView ? this.getCurrentRepositoryRoots(true) : []);
+        if (repositoryRoots.length > 1) {
+            window.withProgress({ location: ProgressLocation.Window, title: 'Updating Tree' }, async _ => {
+                for (const repoRoot of repositoryRoots) {
+                    if (!await this.hydrateRepository(repoRoot)) {
+                        continue;
+                    }
+                    await this.refreshActiveRepository();
+                }
+                this.fireTreeDataChange();
+            });
+            return;
+        }
+        if (!await this.ensureRepositoryForCommand(entry)) {
+            window.showErrorMessage('No repository selected');
+            return;
         }
         window.withProgress({ location: ProgressLocation.Window, title: 'Updating Tree' }, async _ => {
-            try {
-                if (await this.isHeadChanged()) {
-                    // make sure merge base is updated when switching branches
-                    await this.updateRefs(this.baseRef);
-                }
-                await this.updateDiff(true);
-                this.saveRepositoryState();
-            } catch (e: any) {
-                let msg = 'Updating the git tree failed';
-                this.log(msg, e);
-                window.showErrorMessage(`${msg}: ${e.message}`);
-            }
+            await this.refreshActiveRepository();
         });
+    }
+
+    private async refreshActiveRepository() {
+        try {
+            if (await this.isHeadChanged()) {
+                // make sure merge base is updated when switching branches
+                await this.updateRefs(this.baseRef);
+            }
+            await this.updateDiff(true);
+            this.saveRepositoryState();
+        } catch (e: any) {
+            let msg = 'Updating the git tree failed';
+            this.log(msg, e);
+            window.showErrorMessage(`${msg}: ${e.message}`);
+        }
     }
 
     async switchToMergeDiff() {
@@ -1878,9 +2038,8 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
     }
 
     async searchChanges(entry?: RefElement | RepositoryElement) {
-        const repositoryRoot = this.getRepositoryRootFromElement(entry);
-        if (repositoryRoot) {
-            this.loadRepositoryState(repositoryRoot);
+        if (!await this.ensureRepositoryForCommand(entry)) {
+            return;
         }
         const uris = [...this.iterFiles()].map(file => Uri.file(file.dstAbsPath));
         const relativePaths = uris.map(uri => path.relative(this.repoRoot, uri.fsPath));
@@ -1892,9 +2051,8 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
     }
 
     async filterFiles(entry?: RefElement | RepositoryElement) {
-        const repositoryRoot = this.getRepositoryRootFromElement(entry);
-        if (repositoryRoot) {
-            this.loadRepositoryState(repositoryRoot);
+        if (!await this.ensureRepositoryForCommand(entry)) {
+            return;
         }
         const searchTerm = await window.showInputBox({
             prompt: 'Enter text to filter files (leave empty to show all)',
@@ -1914,10 +2072,9 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
         this.fireTreeDataChange();
     }
 
-    clearFilter(entry?: RefElement | RepositoryElement) {
-        const repositoryRoot = this.getRepositoryRootFromElement(entry);
-        if (repositoryRoot) {
-            this.loadRepositoryState(repositoryRoot);
+    async clearFilter(entry?: RefElement | RepositoryElement) {
+        if (!await this.ensureRepositoryForCommand(entry)) {
+            return;
         }
         if (!this.searchFilter) {
             return;

--- a/src/treeProvider.ts
+++ b/src/treeProvider.ts
@@ -74,7 +74,8 @@ class RepoRootElement extends FolderElement {
 }
 
 class RepositoryElement {
-    constructor(public repositoryRoot: string, public label: string, public hasChildren: boolean) {}
+    constructor(public repositoryRoot: string, public label: string, public hasChildren: boolean,
+                public description: string | undefined = undefined) {}
 }
 
 class RefElement {
@@ -84,22 +85,452 @@ class RefElement {
 export type Element = FileElement | FolderElement | RepoRootElement | RepositoryElement | RefElement
 type FileSystemElement = FileElement | FolderElement
 
-interface RepositoryState {
-    repository: Repository | undefined;
-    baseRef: string;
-    workspaceFolder: string;
-    absGitDir: string;
-    repoRoot: FolderAbsPath;
-    headLastChecked: Date;
-    headName: string | undefined;
-    headCommit: string;
-    mergeBase: string;
-    filesInsideTreeRoot: Map<FolderAbsPath, IDiffStatus[]>;
-    filesOutsideTreeRoot: Map<FolderAbsPath, IDiffStatus[]>;
+/**
+ * The subset of the provider that a {@link RepositoryComparison} needs.
+ * Everything here is either global configuration or a global UI concern.
+ */
+interface IComparisonHost {
+    readonly gitApi: GitAPI;
+    readonly globalState: Memento;
+
+    readonly treeRootIsRepo: boolean;
+    readonly fullDiff: boolean;
+    readonly findRenames: boolean;
+    readonly renameThreshold: number;
+    readonly refreshIndex: boolean;
+    readonly omitUntrackedFiles: boolean;
+    readonly omitUnstagedChanges: boolean;
+    readonly showDiffStats: boolean;
+    readonly resetCheckboxOnFileChange: boolean;
+    readonly viewAsList: boolean;
+    readonly sortOrder: SortOrder;
+
+    log(msg: string, error?: Error | undefined): void;
+    fireTreeDataChange(): void;
+}
+
+class ComparisonCreationCancelledError extends Error {
+    constructor() {
+        super('Repository comparison creation was cancelled');
+    }
+}
+
+/**
+ * Owns the complete state of the comparison for a single repository.
+ *
+ * There is one instance per repository, and no state is ever moved between
+ * instances. This is what makes concurrent work on different repositories
+ * safe: an operation holds on to its own instance across `await` boundaries,
+ * so it can no longer be retargeted by rendering or by another repository's
+ * refresh. It also scopes the `@throttle` on `updateDiff` to one repository,
+ * which would otherwise coalesce diffs across repositories.
+ */
+class RepositoryComparison {
     treeRoot: FolderAbsPath;
-    isPaused: boolean;
-    checkboxStates: Map<string, CheckboxStateInfo>;
-    searchFilter: string | undefined;
+
+    baseRef = '';
+    mergeBase = '';
+    headLastChecked = new Date(0);
+    headName: string | undefined = undefined;
+    headCommit = '';
+
+    filesInsideTreeRoot = new Map<FolderAbsPath, IDiffStatus[]>();
+    filesOutsideTreeRoot = new Map<FolderAbsPath, IDiffStatus[]>();
+
+    checkboxStates = new Map<string, CheckboxStateInfo>();
+    searchFilter: string | undefined = undefined;
+
+    private initialLoad: Promise<void> | undefined;
+    private loaded = false;
+
+    /** Whether refs and diff have been computed successfully at least once. */
+    get isLoaded(): boolean {
+        return this.loaded;
+    }
+
+    constructor(
+        private readonly host: IComparisonHost,
+        readonly repository: Repository,
+        readonly repoRoot: FolderAbsPath,
+        readonly absGitDir: string,
+        readonly workspaceFolder: string,
+        readonly isOutsideWorkspace: boolean) {
+        this.treeRoot = this.computeTreeRoot();
+    }
+
+    private computeTreeRoot(): FolderAbsPath {
+        const repoIsWorkspaceSubfolder = this.repoRoot.startsWith(this.workspaceFolder + path.sep);
+        if (this.host.treeRootIsRepo || repoIsWorkspaceSubfolder) {
+            return this.repoRoot;
+        }
+        return this.workspaceFolder;
+    }
+
+    /** Returns true if the tree root changed and the diff has to be recomputed. */
+    updateTreeRootFolder(): boolean {
+        const treeRoot = this.computeTreeRoot();
+        if (treeRoot === this.treeRoot) {
+            return false;
+        }
+        this.treeRoot = treeRoot;
+        return true;
+    }
+
+    /**
+     * Computes refs and diff once. Concurrent callers share the same promise,
+     * so expanding several repositories at the same time cannot start
+     * duplicate work. A failed load is retried on the next call.
+     */
+    ensureLoaded(): Promise<void> {
+        let load = this.initialLoad;
+        if (!load) {
+            load = (async () => {
+                await this.updateRefs();
+                await this.updateDiff(false);
+                this.loaded = true;
+            })();
+            this.initialLoad = load;
+            const pending = load;
+            pending.catch(() => {
+                if (this.initialLoad === pending) {
+                    this.initialLoad = undefined;
+                }
+            });
+        }
+        return load;
+    }
+
+    isInsideTreeRoot(folder: string): boolean {
+        return folder === this.treeRoot || folder.startsWith(this.treeRoot + path.sep);
+    }
+
+    findFile(dstAbsPath: string): IDiffStatus | undefined {
+        const folder = path.dirname(dstAbsPath);
+        const files = this.isInsideTreeRoot(folder) ? this.filesInsideTreeRoot : this.filesOutsideTreeRoot;
+        return files.get(folder)?.find(file => file.dstAbsPath === dstAbsPath);
+    }
+
+    *iterFiles(withinFolder: string | undefined = undefined) {
+        for (let filesMap of [this.filesInsideTreeRoot, this.filesOutsideTreeRoot]) {
+            for (let [folder, files] of filesMap.entries()) {
+                // Compare whole path segments, otherwise "src/foo" would also
+                // match the sibling folder "src/foobar".
+                if (withinFolder && folder !== withinFolder &&
+                        !folder.startsWith(withinFolder + path.sep)) {
+                    continue;
+                }
+                for (let file of files) {
+                    if (!file.isSubmodule) {
+                        yield file;
+                    }
+                }
+            }
+        }
+    }
+
+    clearFiles() {
+        this.filesInsideTreeRoot = new Map();
+        this.filesOutsideTreeRoot = new Map();
+    }
+
+    private async getStoredBaseRef(): Promise<string | undefined> {
+        let baseRef = this.host.globalState.get<string>('baseRef_' + this.repoRoot);
+        if (baseRef) {
+            if (await this.isRefExisting(baseRef) || await this.isCommitExisting(baseRef)) {
+                this.host.log('Using stored base ref: ' + baseRef);
+            } else {
+                this.host.log('Not using non-existant stored base ref: ' + baseRef);
+                baseRef = undefined;
+            }
+        }
+        return baseRef;
+    }
+
+    async isRefExisting(refName: string): Promise<boolean> {
+        const refs = await this.repository.getRefs();
+        return refs.some(ref => ref.name === refName);
+    }
+
+    async isCommitExisting(id: string): Promise<boolean> {
+        try {
+            await this.repository.getCommit(id);
+            return true;
+        } catch {
+            return false;
+        }
+    }
+
+    private updateStoredBaseRef(baseRef: string) {
+        this.host.globalState.update('baseRef_' + this.repoRoot, baseRef);
+    }
+
+    async isHeadChanged(): Promise<boolean> {
+        // Note that we can't rely on filesystem change notifications for .git/HEAD
+        // because the workspace root may be a subfolder of the repo root
+        // and change notifications are currently limited to workspace scope.
+        // See https://github.com/Microsoft/vscode/issues/3025.
+        const mtime = await getHeadModificationDate(this.absGitDir);
+        if (mtime > this.headLastChecked) {
+            return true;
+        }
+        // At this point we know that HEAD still points to the same symbolic ref or commit (if detached).
+        // If HEAD is not detached, check if the symbolic ref resolves to a different commit.
+        if (this.headName) {
+            // this.repository.getBranch() is not used here to avoid git invocation overhead
+            const headCommit = await getBranchCommit(this.headName, this.repository);
+            if (this.headCommit !== headCommit) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    async updateRefs(baseRef?: string): Promise<void> {
+        this.host.log(`Updating refs: ${this.repoRoot}`);
+        const headLastChecked = new Date();
+        const HEAD = await this.repository.getHEAD();
+        // if detached HEAD, then .commit exists, otherwise only .name
+        const headName = HEAD.name;
+        const headCommit = HEAD.commit || await getBranchCommit(HEAD.name!, this.repository);
+        if (baseRef) {
+            const exists = await this.isRefExisting(baseRef) || await this.isCommitExisting(baseRef);
+            if (!exists) {
+                // happens when branch was deleted
+                baseRef = undefined;
+            }
+        }
+        if (!baseRef) {
+            baseRef = await this.getStoredBaseRef();
+        }
+        if (!baseRef) {
+            baseRef = await getDefaultBranch(this.repository, HEAD);
+        }
+        if (!baseRef) {
+            if (HEAD.name) {
+                baseRef = HEAD.name;
+            } else {
+                // detached HEAD and no default branch was found
+                // pick an arbitrary ref as base, give preference to common refs
+                const refs = await this.repository.getRefs();
+                const commonRefs = ['origin/main', 'main', 'origin/master', 'master'];
+                const match = refs.find(ref => ref.name !== undefined && commonRefs.indexOf(ref.name) !== -1);
+                if (match) {
+                    baseRef = match.name;
+                } else if (refs.length > 0) {
+                    baseRef = refs[0].name;
+                }
+            }
+        }
+        if (!baseRef) {
+            // this should never happen
+            throw new Error('Base ref could not be determined!');
+        }
+        const HEADref: string = (HEAD.name || HEAD.commit)!;
+        let mergeBase = baseRef;
+        if (!this.host.fullDiff && baseRef != HEAD.name) {
+            // determine merge base to create more sensible/compact diff
+            let mergeBaseResult: string | undefined;
+            try {
+                mergeBaseResult = await this.repository.getMergeBase(HEADref, baseRef);
+            } catch (e) {
+                // sometimes the merge base cannot be determined
+                // this can be the case with shallow clones but may have other reasons
+            }
+            if (!mergeBaseResult) {
+                const gitApiRepo = this.host.gitApi.getRepository(Uri.file(this.repository.root));
+                if (gitApiRepo) {
+                    mergeBaseResult = await tryDeepenForMergeBase(
+                        this.repository, gitApiRepo, HEADref, HEAD.name, baseRef,
+                        msg => this.host.log(msg));
+                }
+            }
+            if (!mergeBaseResult) {
+                throw new Error(
+                    `No merge base could be found between "${HEADref}" and "${baseRef}". ` +
+                    `This can happen with shallow clones that don't have enough depth. ` +
+                    `Try fetching more history, or switch the diff mode to "full".`);
+            }
+            mergeBase = mergeBaseResult;
+        }
+        if (this.headName !== headName) {
+            this.host.log(`HEAD ref updated: ${this.headName} -> ${headName}`);
+            this.checkboxStates.clear();
+        }
+        if (this.headCommit !== headCommit) {
+            this.host.log(`HEAD ref commit updated: ${this.headCommit} -> ${headCommit}`);
+        }
+        if (this.baseRef !== baseRef) {
+            this.host.log(`Base ref updated: ${this.baseRef} -> ${baseRef}`);
+        }
+        if (!this.host.fullDiff && this.mergeBase !== mergeBase) {
+            this.host.log(`Merge base updated: ${this.mergeBase} -> ${mergeBase}`);
+        }
+        this.headLastChecked = headLastChecked;
+        this.headName = headName;
+        this.headCommit = headCommit;
+        this.baseRef = baseRef;
+        this.mergeBase = mergeBase;
+        this.updateStoredBaseRef(baseRef);
+    }
+
+    @throttle
+    async updateDiff(fireChangeEvents: boolean) {
+        if (!this.baseRef) {
+            await this.updateRefs();
+        }
+
+        const filesInsideTreeRoot = new Map<FolderAbsPath, IDiffStatus[]>();
+        const filesOutsideTreeRoot = new Map<FolderAbsPath, IDiffStatus[]>();
+
+        const diff = await diffIndex(this.repository, this.mergeBase, this.host.refreshIndex, this.host.findRenames,
+            this.host.renameThreshold, this.host.omitUntrackedFiles, this.host.omitUnstagedChanges, this.host.showDiffStats);
+        const untrackedCount = diff.reduce((prev, cur, _) => prev + (cur.status === 'U' ? 1 : 0), 0);
+        this.host.log(`${diff.length} diff entries (${untrackedCount} untracked)`);
+
+        if (diff.length > MAX_DIFF_ENTRIES) {
+            const msg = `Too many changes to display (${diff.length}, limit is ${MAX_DIFF_ENTRIES}). Choose a closer base ref to reduce the number of changes.`;
+            this.host.log(msg);
+            window.showErrorMessage(msg);
+            this.clearFiles();
+            if (fireChangeEvents) {
+                this.host.fireTreeDataChange();
+            }
+            return;
+        }
+
+        const newFilePaths = new Set<string>();
+        // Collect files that need mtime checking for async batch processing
+        const filesToCheckMtime: Array<{filePath: string, stateInfo: CheckboxStateInfo}> = [];
+
+        for (const entry of diff) {
+            const folder = path.dirname(entry.dstAbsPath);
+
+            const isInsideTreeRoot = this.isInsideTreeRoot(folder);
+            const files = isInsideTreeRoot ? filesInsideTreeRoot : filesOutsideTreeRoot;
+            const rootFolder = isInsideTreeRoot ? this.treeRoot : this.repoRoot;
+
+            if (files.size == 0) {
+                files.set(rootFolder, new Array());
+            }
+
+            // add this and all parent folders to the folder map
+            let currentFolder = folder
+            while (currentFolder != rootFolder) {
+                if (!files.has(currentFolder)) {
+                    files.set(currentFolder, new Array());
+                }
+                currentFolder = path.dirname(currentFolder)
+            }
+
+            const entries = files.get(folder)!;
+            entries.push(entry);
+
+            // Track new file paths
+            newFilePaths.add(entry.dstAbsPath);
+
+            // Collect checked files for mtime checking to reset if modified after being checked
+            if (this.host.resetCheckboxOnFileChange) {
+                const stateInfo = this.checkboxStates.get(entry.dstAbsPath);
+                if (stateInfo && stateInfo.state === TreeItemCheckboxState.Checked) {
+                    filesToCheckMtime.push({filePath: entry.dstAbsPath, stateInfo});
+                }
+            }
+        }
+
+        // Check file modification times asynchronously in parallel
+        if (this.host.resetCheckboxOnFileChange && filesToCheckMtime.length > 0) {
+            const statPromises = filesToCheckMtime.map(async ({filePath, stateInfo}) => {
+                try {
+                    const stats = await fs.promises.stat(filePath);
+                    const fileMtime = stats.mtimeMs;
+
+                    // If file was modified after checkbox was checked, reset it
+                    if (fileMtime > stateInfo.timestamp) {
+                        return filePath;
+                    }
+                } catch (error: unknown) {
+                    // File might be deleted or inaccessible - this is expected in some cases
+                    const errorMessage = error instanceof Error ? error.message : String(error);
+                    this.host.log(`Could not stat file for checkbox reset check: ${filePath}: ${errorMessage}`);
+                }
+                return null;
+            });
+
+            const pathsToReset = await Promise.all(statPromises);
+            const actualPathsToReset = pathsToReset.filter((filePath): filePath is string => filePath !== null);
+            actualPathsToReset.forEach(filePath => this.checkboxStates.delete(filePath));
+
+            // Fire tree refresh to update checkbox UI
+            if (actualPathsToReset.length > 0) {
+                this.host.fireTreeDataChange();
+            }
+        }
+
+        // Clear checkbox state for files that no longer exist in the diff
+        const pathsToDelete: string[] = [];
+        for (const [filePath] of this.checkboxStates) {
+            if (!newFilePaths.has(filePath)) {
+                pathsToDelete.push(filePath);
+            }
+        }
+        for (const filePath of pathsToDelete) {
+            this.checkboxStates.delete(filePath);
+        }
+
+        let treeHasChanged = false;
+        if (fireChangeEvents) {
+            const hasChanged = (folderPath: string, insideTreeRoot: boolean) => {
+                const oldFiles = insideTreeRoot ? this.filesInsideTreeRoot : this.filesOutsideTreeRoot;
+                const newFiles = insideTreeRoot ? filesInsideTreeRoot : filesOutsideTreeRoot;
+                const oldItems = oldFiles.get(folderPath)!.map(f => `${f.status}|${f.dstAbsPath}`);
+                const newItems = newFiles.get(folderPath)!.map(f => `${f.status}|${f.dstAbsPath}`);
+                for (const {files, items} of [{files: oldFiles, items: oldItems},
+                                              {files: newFiles, items: newItems}]) {
+                    // add direct subdirectories to items list
+                    for (const folder of files.keys()) {
+                        if (path.dirname(folder) === folderPath) {
+                            items.push(folder);
+                        }
+                    }
+                }
+                return !sortedArraysEqual(oldItems, newItems);
+            }
+
+            const treeRootChanged = !filesInsideTreeRoot.size !== !this.filesInsideTreeRoot.size;
+            const mustAddOrRemoveRepoRootElement = !filesOutsideTreeRoot.size !== !this.filesOutsideTreeRoot.size;
+            if (treeRootChanged || mustAddOrRemoveRepoRootElement) {
+                treeHasChanged = true;
+            } else {
+                for (const folder of filesInsideTreeRoot.keys()) {
+                    if (!this.filesInsideTreeRoot.has(folder) ||
+                            hasChanged(folder, true)) {
+                        treeHasChanged = true;
+                        break;
+                    }
+                }
+                if (!treeHasChanged) {
+                    for (const folder of filesOutsideTreeRoot.keys()) {
+                        if (!this.filesOutsideTreeRoot.has(folder) ||
+                                hasChanged(folder, false)) {
+                            treeHasChanged = true;
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        this.filesInsideTreeRoot = filesInsideTreeRoot;
+        this.filesOutsideTreeRoot = filesOutsideTreeRoot;
+
+        // Always refresh when sorting by recently modified in list view, as file mtimes may have changed
+        const needsRefreshForSorting = this.host.viewAsList && this.host.sortOrder === 'recentlyModified';
+
+        if (fireChangeEvents && (treeHasChanged || needsRefreshForSorting || this.host.showDiffStats)) {
+            this.host.log('Refreshing tree')
+            this.host.fireTreeDataChange();
+        }
+    }
 }
 
 class ChangeBaseRefItem implements QuickPickItem {
@@ -136,79 +567,68 @@ class ChangeRepositoryItem implements QuickPickItem {
 
 type FolderAbsPath = string;
 
-export class GitTreeCompareProvider implements TreeDataProvider<Element>, Disposable {
+export class GitTreeCompareProvider implements TreeDataProvider<Element>, Disposable, IComparisonHost {
 
     // Events
     private _onDidChangeTreeData = new EventEmitter<Element | void>();
     readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
 
-    private fireTreeDataChange() {
+    fireTreeDataChange() {
         this.parentMap.clear();
         this.elementMap.clear();
         this._onDidChangeTreeData.fire();
     }
 
     // Configuration options
-    private treeRootIsRepo: boolean;
+    treeRootIsRepo: boolean;
     private includeFilesOutsideWorkspaceFolderRoot: boolean;
     private openChangesOnSelect: boolean;
     private autoChangeRepository: boolean;
     private multiRepositoryView: boolean;
     private autoRefresh: boolean;
-    private refreshIndex: boolean;
+    refreshIndex: boolean;
     private iconsMinimal: boolean;
     private iconStyle: IconStyle;
-    private fullDiff: boolean;
-    private findRenames: boolean;
-    private renameThreshold: number;
+    fullDiff: boolean;
+    findRenames: boolean;
+    renameThreshold: number;
     private showCollapsed: boolean;
     private compactFolders: boolean;
     private showCheckboxes: boolean;
-    private resetCheckboxOnFileChange: boolean;
-    private omitUntrackedFiles: boolean;
-    private omitUnstagedChanges: boolean;
-    private sortOrder: SortOrder;
+    resetCheckboxOnFileChange: boolean;
+    omitUntrackedFiles: boolean;
+    omitUnstagedChanges: boolean;
+    sortOrder: SortOrder;
     private autoReveal: boolean;
-    private showDiffStats: boolean;
+    showDiffStats: boolean;
+
+    // One comparison per repository, keyed by canonical repository root.
+    private comparisons = new Map<FolderAbsPath, RepositoryComparison>();
+    // Maps any path used to look up a repository to its canonical root.
+    private rootAliases = new Map<string, FolderAbsPath>();
+    // In-flight creations, so concurrent lookups share one RepositoryComparison.
+    private pendingComparisons = new Map<string, Promise<RepositoryComparison>>();
+    // Incremented whenever repository membership is reset. Async creations
+    // must match the current generation before publishing any state.
+    private comparisonGeneration = 0;
+    // Load failures already reported to the user, to avoid repeating a dialog
+    // for the same persistent error on every tree refresh.
+    private reportedLoadErrors = new Map<string, string>();
+    // The repository shown when the tree does not show repository nodes.
+    private activeComparison: RepositoryComparison | undefined;
 
     // Dynamic options
-    private repository: Repository | undefined;
-    private baseRef: string;
-    private viewAsList = false;
+    viewAsList = false;
     private hideCheckedFiles = false;
-    private searchFilter: string | undefined;
-    private repositoryStates: Map<string, RepositoryState> = new Map();
-    private repositoryRootAliases: Map<string, string> = new Map();
-    private activeRepoRoot: string | undefined;
-
-    // Static state of repository
-    private workspaceFolder: string;
-    private absGitDir: string;
-    private repoRoot: FolderAbsPath;
-
-    // Dynamic state of repository
-    private headLastChecked: Date;
-    private headName: string | undefined; // undefined if detached
-    private headCommit: string;
-
-    // Diff parameters, derived
-    private mergeBase: string;
-
-    // Diff results
-    private filesInsideTreeRoot: Map<FolderAbsPath, IDiffStatus[]>;
-    private filesOutsideTreeRoot: Map<FolderAbsPath, IDiffStatus[]>;
-
-    // UI parameters, derived
-    private treeRoot: FolderAbsPath;
 
     // UI state
     private treeView: TreeView<Element>;
-    private isPaused: boolean;
-    private checkboxStates: Map<string, CheckboxStateInfo> = new Map<string, CheckboxStateInfo>();
     private parentMap: Map<string, Element> = new Map();
     private elementMap: Map<string, FileElement> = new Map();
-    private pendingRefreshRepositories = new Map<string, Uri>();
+    private pendingRefreshRoots = new Set<FolderAbsPath>();
     private pendingRefreshTimer: NodeJS.Timeout | undefined;
+    private refreshInProgress = false;
+    private disposed = false;
     // Incremented on each "Collapse All". Changing folder ids makes VS Code
     // apply their collapsed state instead of restoring their previous state.
     // The ref keeps its stable id and remains expanded.
@@ -216,144 +636,160 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
 
     // Other
     private readonly disposables: Disposable[] = [];
-    private extraRepositoryWatcher: Disposable | undefined;
+    private extraRepositoryWatchers = new Map<FolderAbsPath, Disposable>();
+    private repositoryUiSubscriptions = new Map<string, Disposable>();
 
-    constructor(private readonly git: Git, private readonly gitApi: GitAPI, private readonly outputChannel: OutputChannel, private readonly globalState: Memento,
+    constructor(private readonly git: Git, readonly gitApi: GitAPI, private readonly outputChannel: OutputChannel, readonly globalState: Memento,
                 private readonly asAbsolutePath: (relPath: string) => string) {
         this.readConfig();
     }
 
-    private captureRepositoryState(): RepositoryState | undefined {
-        if (!this.activeRepoRoot || !this.repository) {
-            return;
-        }
-        return {
-            repository: this.repository,
-            baseRef: this.baseRef,
-            workspaceFolder: this.workspaceFolder,
-            absGitDir: this.absGitDir,
-            repoRoot: this.repoRoot,
-            headLastChecked: this.headLastChecked,
-            headName: this.headName,
-            headCommit: this.headCommit,
-            mergeBase: this.mergeBase,
-            filesInsideTreeRoot: this.filesInsideTreeRoot,
-            filesOutsideTreeRoot: this.filesOutsideTreeRoot,
-            treeRoot: this.treeRoot,
-            isPaused: this.isPaused,
-            checkboxStates: this.checkboxStates,
-            searchFilter: this.searchFilter,
-        };
+    /**
+     * Single source of truth for the tree layout: repository nodes are only
+     * shown when the feature is enabled *and* there is more than one
+     * repository. A single repository always uses the original layout.
+     */
+    private showRepositoryNodes(): boolean {
+        return this.multiRepositoryView && this.getRepositoryRoots().length > 1;
     }
 
-    private saveRepositoryState() {
-        const state = this.captureRepositoryState();
-        if (state) {
-            this.repositoryStates.set(state.repoRoot, state);
-        }
-    }
-
-    private loadRepositoryState(repositoryRoot: string): boolean {
-        const repoRoot = this.resolveRepositoryRootAlias(repositoryRoot);
-        const state = this.repositoryStates.get(repoRoot);
-        if (!state) {
-            return false;
-        }
-        this.repository = state.repository;
-        this.baseRef = state.baseRef;
-        this.workspaceFolder = state.workspaceFolder;
-        this.absGitDir = state.absGitDir;
-        this.repoRoot = state.repoRoot;
-        this.headLastChecked = state.headLastChecked;
-        this.headName = state.headName;
-        this.headCommit = state.headCommit;
-        this.mergeBase = state.mergeBase;
-        this.filesInsideTreeRoot = state.filesInsideTreeRoot;
-        this.filesOutsideTreeRoot = state.filesOutsideTreeRoot;
-        this.treeRoot = state.treeRoot;
-        this.isPaused = state.isPaused;
-        this.checkboxStates = state.checkboxStates;
-        this.searchFilter = state.searchFilter;
-        this.activeRepoRoot = state.repoRoot;
-        return true;
-    }
-
-    private async useRepository(repositoryRoot: string): Promise<boolean> {
-        const repoRoot = this.resolveRepositoryRootAlias(repositoryRoot);
-        if (this.activeRepoRoot === repoRoot && this.repository) {
-            return true;
-        }
-        this.saveRepositoryState();
-        if (this.loadRepositoryState(repoRoot)) {
-            return true;
-        }
-        await this.setRepository(repoRoot);
-        return true;
-    }
-
-    private async hydrateRepository(repositoryRoot: string): Promise<boolean> {
-        try {
-            const hadState = this.repositoryStates.has(this.resolveRepositoryRootAlias(repositoryRoot));
-            await this.useRepository(repositoryRoot);
-            if (!hadState || !this.baseRef) {
-                await this.updateRefs();
-            }
-            if (!hadState) {
-                await this.updateDiff(false);
-            }
-            this.saveRepositoryState();
-            return true;
-        } catch (e: any) {
-            this.log(`Ignoring repository ${repositoryRoot}`, e);
-            return false;
-        }
-    }
-
-    private getCurrentRepositoryRoots(selectedFirst=false): string[] {
+    /** Workspace repository roots, de-duplicated by canonical root. */
+    private getRepositoryRoots(selectedFirst=false): string[] {
         const roots = getGitRepositoryFolders(this.gitApi, selectedFirst).map(normalizePath);
         const uniqueRoots: string[] = [];
         const seen = new Set<string>();
         for (const root of roots) {
-            const resolvedRoot = this.resolveRepositoryRootAlias(root);
-            if (!seen.has(resolvedRoot)) {
+            const canonical = this.rootAliases.get(root) ?? root;
+            if (!seen.has(canonical)) {
                 uniqueRoots.push(root);
-                seen.add(resolvedRoot);
+                seen.add(canonical);
             }
         }
         return uniqueRoots;
     }
 
-    private resolveRepositoryRootAlias(repositoryRoot: string): string {
+    private getExistingComparison(repositoryRoot: string): RepositoryComparison | undefined {
         const normalized = normalizePath(repositoryRoot);
-        return this.repositoryRootAliases.get(normalized) ?? normalized;
+        const canonical = this.rootAliases.get(normalized) ?? normalized;
+        return this.comparisons.get(canonical);
     }
 
-    private getRepositoryRootFromElement(element: Element | undefined): string | undefined {
-        return element?.repositoryRoot;
+    /**
+     * Returns the comparison for a repository, creating it if necessary.
+     * Concurrent calls for the same repository share a single creation, so a
+     * repository can never end up with two diverging comparison objects.
+     */
+    private async getComparison(repositoryRoot: string): Promise<RepositoryComparison> {
+        const existing = this.getExistingComparison(repositoryRoot);
+        if (existing) {
+            return existing;
+        }
+        const requested = normalizePath(repositoryRoot);
+        let pending = this.pendingComparisons.get(requested);
+        if (!pending) {
+            pending = this.createComparison(requested, this.comparisonGeneration);
+            this.pendingComparisons.set(requested, pending);
+            const creation = pending;
+            const settled = () => {
+                if (this.pendingComparisons.get(requested) === creation) {
+                    this.pendingComparisons.delete(requested);
+                }
+            };
+            pending.then(settled, settled);
+        }
+        return pending;
     }
 
-    private async ensureRepositoryForCommand(element: Element | undefined): Promise<boolean> {
-        const repositoryRoot = this.getRepositoryRootFromElement(element);
-        if (repositoryRoot) {
-            return await this.hydrateRepository(repositoryRoot);
+    private invalidateComparisonCreations() {
+        this.comparisonGeneration++;
+        this.pendingComparisons.clear();
+    }
+
+    /** Returns a fully loaded comparison, or undefined if the repository is unusable. */
+    private async loadComparison(repositoryRoot: string): Promise<RepositoryComparison | undefined> {
+        const key = normalizePath(repositoryRoot);
+        try {
+            const comparison = await this.getComparison(repositoryRoot);
+            await comparison.ensureLoaded();
+            this.reportedLoadErrors.delete(key);
+            return comparison;
+        } catch (e: any) {
+            if (e instanceof ComparisonCreationCancelledError) {
+                return undefined;
+            }
+            const msg = `Comparing repository ${path.basename(key)} failed`;
+            this.log(`${msg} (${key})`, e);
+            // getChildren() retries on every tree refresh, so report a given
+            // failure only once, until the repository loads again or starts
+            // failing for a different reason.
+            if (this.reportedLoadErrors.get(key) !== e.message) {
+                this.reportedLoadErrors.set(key, e.message);
+                window.showErrorMessage(`${msg}: ${e.message}`);
+            }
+            return undefined;
         }
-        if (this.repository) {
-            return true;
+    }
+
+    /**
+     * Resolves which repository a command acts on. Commands invoked from the
+     * tree carry the repository in their element. Commands invoked from the
+     * command palette use the active repository, or ask when several
+     * repositories are shown, instead of silently picking one.
+     */
+    private async resolveRepositoryRoot(element?: Element): Promise<string | undefined> {
+        if (element) {
+            return element.repositoryRoot;
         }
-        const gitRepos = this.getCurrentRepositoryRoots(true);
-        if (gitRepos.length === 1) {
-            return await this.hydrateRepository(gitRepos[0]);
+        if (!this.showRepositoryNodes()) {
+            if (this.activeComparison) {
+                return this.activeComparison.repoRoot;
+            }
+            const roots = this.getRepositoryRoots(true);
+            return roots[0];
         }
-        return false;
+        const picks = this.getRepositoryRoots(true).map(root => new ChangeRepositoryItem(root));
+        const choice = await window.showQuickPick<ChangeRepositoryItem>(picks,
+            { placeHolder: 'Select a repository' });
+        return choice?.repositoryRoot;
+    }
+
+    private async resolveComparison(element?: Element): Promise<RepositoryComparison | undefined> {
+        const repositoryRoot = await this.resolveRepositoryRoot(element);
+        return repositoryRoot ? await this.loadComparison(repositoryRoot) : undefined;
+    }
+
+    /**
+     * Finds the repository a changed path belongs to. This deliberately
+     * searches known comparisons rather than workspace repositories, so that
+     * repositories outside the workspace (linked worktrees) and repositories
+     * whose git dir lives elsewhere keep receiving auto refreshes.
+     */
+    private findComparisonForPath(absPath: string): RepositoryComparison | undefined {
+        const normPath = normalizePath(absPath);
+        let best: RepositoryComparison | undefined;
+        let bestLength = -1;
+        for (const comparison of this.comparisons.values()) {
+            const bases = [comparison.repoRoot, normalizePath(comparison.absGitDir)];
+            for (const base of bases) {
+                if (normPath !== base && !normPath.startsWith(base + path.sep)) {
+                    continue;
+                }
+                if (base.length > bestLength) {
+                    bestLength = base.length;
+                    best = comparison;
+                }
+            }
+        }
+        return best;
     }
 
     async init(treeView: TreeView<Element>) {
         this.treeView = treeView
 
-        // Use the original single-repository behavior unless multi-repo view
-        // actually has multiple repositories to display.
-        const gitRepos = this.getCurrentRepositoryRoots(true);
-        if (!this.multiRepositoryView || gitRepos.length === 1) {
+        // Use the original single-repository behavior unless the tree actually
+        // shows repository nodes.
+        if (!this.showRepositoryNodes()) {
+            const gitRepos = this.getRepositoryRoots(true);
             if (gitRepos.length > 0) {
                 await this.changeRepository(gitRepos[0]);
             }
@@ -363,8 +799,9 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
         this.disposables.push(workspace.onDidChangeWorkspaceFolders(this.handleWorkspaceFoldersChanged, this));
         this.disposables.push(window.registerFileDecorationProvider(new GitTreeCompareFileDecorationProvider()));
         this.disposables.push(this.gitApi.onDidOpenRepository(this.handleRepositoryOpened, this));
+        this.disposables.push(this.gitApi.onDidCloseRepository(this.handleRepositoryClosed, this));
         for (const repository of this.gitApi.repositories) {
-            this.disposables.push(repository.ui.onDidChange(() => this.handleRepositoryUiChange(repository)));
+            this.watchRepositoryUi(repository);
         }
 
         const fsWatcher = workspace.createFileSystemWatcher('**');
@@ -376,22 +813,23 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
         this.disposables.push(treeView.onDidChangeCheckboxState(this.handleChangeCheckboxState, this));
         this.disposables.push(window.onDidChangeActiveTextEditor(this.handleActiveEditorChange, this));
         this.disposables.push(new Disposable(() => {
+            this.disposed = true;
             if (this.pendingRefreshTimer) {
                 clearTimeout(this.pendingRefreshTimer);
+                this.pendingRefreshTimer = undefined;
             }
         }));
+
+        this.updateViewState();
     }
 
-    async setRepository(repositoryRoot: string) {
-        this.saveRepositoryState();
+    private async createComparison(repositoryRoot: string, generation: number): Promise<RepositoryComparison> {
         const requestedRepositoryRoot = normalizePath(repositoryRoot);
         const actualRepositoryRoot = normalizePath(await this.git.getRepositoryRoot(requestedRepositoryRoot));
         const dotGit = await this.git.getRepositoryDotGit(actualRepositoryRoot);
         const repository = this.git.open(actualRepositoryRoot, dotGit);
         const absGitDir = await getAbsGitDir(repository);
         const repoRoot = normalizePath(repository.root);
-        this.repositoryRootAliases.set(requestedRepositoryRoot, repoRoot);
-        this.repositoryRootAliases.set(repoRoot, repoRoot);
 
         const workspaceFolders = getWorkspaceFolders(repoRoot);
         const outsideWorkspace = workspaceFolders.length == 0;
@@ -404,21 +842,6 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
             workspaceFolders.push({ uri: Uri.file(repoRoot), name: path.basename(repoRoot), index: 0 });
         }
 
-        this.repository = repository;
-        this.absGitDir = absGitDir;
-        this.repoRoot = repoRoot;
-        this.activeRepoRoot = repoRoot;
-        this.baseRef = '';
-        this.mergeBase = '';
-        this.headLastChecked = new Date(0);
-        this.headName = undefined;
-        this.headCommit = '';
-        this.filesInsideTreeRoot = new Map();
-        this.filesOutsideTreeRoot = new Map();
-        this.checkboxStates = new Map();
-        this.searchFilter = undefined;
-        this.isPaused = false;
-
         // Sort descending by folder depth
         workspaceFolders.sort((a, b) => {
             const aDepth = a.uri.fsPath.split(path.sep).length;
@@ -427,96 +850,112 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
         });
         // If repo appears in multiple workspace folders, pick the deepest one.
         // TODO let the user choose which one
-        this.workspaceFolder = normalizePath(workspaceFolders[0].uri.fsPath);
-        this.updateTreeRootFolder();
-        this.log('Using repository: ' + this.repoRoot);
-        this.updateExtraRepositoryWatcher(outsideWorkspace);
+        const workspaceFolder = normalizePath(workspaceFolders[0].uri.fsPath);
 
-        this.updateTreeTitle();
+        if (generation !== this.comparisonGeneration) {
+            throw new ComparisonCreationCancelledError();
+        }
+
+        this.rootAliases.set(requestedRepositoryRoot, repoRoot);
+        this.rootAliases.set(repoRoot, repoRoot);
+
+        // A different alias may have created the comparison while we awaited.
+        const existing = this.comparisons.get(repoRoot);
+        if (existing) {
+            return existing;
+        }
+
+        const comparison = new RepositoryComparison(
+            this, repository, repoRoot, absGitDir, workspaceFolder, outsideWorkspace);
+        this.comparisons.set(repoRoot, comparison);
+        this.log('Using repository: ' + repoRoot);
+        this.addExtraRepositoryWatcher(comparison);
+        return comparison;
     }
 
-    private updateTreeTitle() {
-        if (!this.multiRepositoryView) {
-            if (!this.repository) {
-                this.treeView.title = 'none';
-                return;
-            }
-            const repoName = path.basename(this.repoRoot);
-            if (this.searchFilter) {
-                this.treeView.title = `${repoName} (filtered)`;
-            } else {
-                this.treeView.title = repoName;
-            }
+    /**
+     * Publishes everything derived from the current layout: the view title and
+     * the context keys that menus depend on. Menu visibility must be driven by
+     * `showRepositoryNodes` rather than by the raw setting or by the git
+     * extension's repository count, because neither of those matches the
+     * layout this provider actually renders.
+     */
+    private updateViewState() {
+        const showRepositoryNodes = this.showRepositoryNodes();
+        commands.executeCommand('setContext', NAMESPACE + '.showRepositoryNodes', showRepositoryNodes);
+
+        const isFiltered = showRepositoryNodes
+            ? [...this.comparisons.values()].some(c => c.searchFilter)
+            : !!this.activeComparison?.searchFilter;
+        commands.executeCommand('setContext', NAMESPACE + '.isFiltered', isFiltered);
+
+        if (!this.treeView) {
             return;
         }
-        const repoCount = this.getCurrentRepositoryRoots().length;
-        if (repoCount === 0) {
+        if (showRepositoryNodes) {
+            this.treeView.title = isFiltered ? 'Git Tree Compare (filtered)' : 'Git Tree Compare';
+            return;
+        }
+        const comparison = this.activeComparison;
+        if (!comparison) {
             this.treeView.title = 'none';
             return;
         }
-        if (repoCount === 1 && this.repository) {
-            const repoName = path.basename(this.repoRoot);
-            if (this.searchFilter) {
-                this.treeView.title = `${repoName} (filtered)`;
-            } else {
-                this.treeView.title = repoName;
-            }
-            return;
-        }
-        const hasFilter = [...this.repositoryStates.values()].some(state => state.searchFilter);
-        if (hasFilter) {
-            this.treeView.title = `Git Tree Compare (filtered)`;
-        } else {
-            this.treeView.title = 'Git Tree Compare';
-        }
-    }
-
-    private updateTreeTitleForCurrentRepository() {
-        if (!this.repository || this.getCurrentRepositoryRoots().length !== 1) {
-            this.updateTreeTitle();
-            return;
-        }
-        const repoName = path.basename(this.repoRoot);
-        if (this.searchFilter) {
-            this.treeView.title = `${repoName} (filtered)`;
-        } else {
-            this.treeView.title = repoName;
-        }
+        const repoName = path.basename(comparison.repoRoot);
+        this.treeView.title = comparison.searchFilter ? `${repoName} (filtered)` : repoName;
     }
 
     async unsetRepository() {
-        this.repository = undefined;
-        this.activeRepoRoot = undefined;
-        this.repositoryStates.clear();
-        this.updateExtraRepositoryWatcher(false);
+        this.invalidateComparisonCreations();
+        this.activeComparison = undefined;
+        this.comparisons.clear();
+        this.rootAliases.clear();
+        this.reportedLoadErrors.clear();
+        this.disposeExtraRepositoryWatchers();
         this.fireTreeDataChange();
         this.log('No repository selected');
 
-        this.updateTreeTitle();
+        this.updateViewState();
     }
 
     async changeRepository(repositoryRoot: string) {
+        let comparison: RepositoryComparison;
         try {
-            await this.setRepository(repositoryRoot);
-            await this.updateRefs();
-            await this.updateDiff(false);
-            this.saveRepositoryState();
+            comparison = await this.getComparison(repositoryRoot);
         } catch (e: any) {
+            if (e instanceof ComparisonCreationCancelledError) {
+                return;
+            }
             let msg = 'Changing the repository failed';
             this.log(msg, e);
             window.showErrorMessage(`${msg}: ${e.message}`);
             return;
         }
-        this.checkboxStates.clear();
-        this.searchFilter = undefined;
-        this.updateFilterContext();
-        this.saveRepositoryState();
+        // Select the repository even if loading fails, so that a transient
+        // error does not leave the view stuck on no repository at all.
+        this.activeComparison = comparison;
+        if (comparison.isLoaded) {
+            // ensureLoaded() is a no-op once loaded, so refresh explicitly to
+            // avoid showing a stale diff when switching back to a repository.
+            await this.refreshComparison(comparison, true);
+        } else {
+            try {
+                await comparison.ensureLoaded();
+            } catch (e: any) {
+                let msg = 'Changing the repository failed';
+                this.log(msg, e);
+                window.showErrorMessage(`${msg}: ${e.message}`);
+            }
+        }
+        this.updateViewState();
         this.fireTreeDataChange();
     }
 
     async promptChangeRepository() {
-        const gitRepos = getGitRepositoryFolders(this.gitApi);
-        const gitReposWithoutCurrent = gitRepos.filter(w => this.repoRoot !== w);
+        const activeRoot = this.activeComparison?.repoRoot;
+        const gitRepos = this.getRepositoryRoots();
+        const gitReposWithoutCurrent = gitRepos.filter(
+            root => (this.rootAliases.get(root) ?? root) !== activeRoot);
         const picks = gitReposWithoutCurrent.map(r => new ChangeRepositoryItem(r));
         const placeHolder = 'Select a repository';
         const choice = await window.showQuickPick<ChangeRepositoryItem>(picks, { placeHolder });
@@ -529,27 +968,41 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
     }
 
     private async handleRepositoryOpened(repository: GitAPIRepository) {
-        const gitRepos = this.getCurrentRepositoryRoots(true);
-        if ((!this.multiRepositoryView || gitRepos.length === 1) && this.repository === undefined) {
+        if (!this.showRepositoryNodes() && this.activeComparison === undefined) {
             await this.changeRepository(repository.rootUri.fsPath);
+        } else {
+            this.updateViewState();
+            this.fireTreeDataChange();
         }
-        this.fireTreeDataChange();
-        this.disposables.push(repository.ui.onDidChange(() => this.handleRepositoryUiChange(repository)));
+        this.watchRepositoryUi(repository);
+    }
+
+    private watchRepositoryUi(repository: GitAPIRepository) {
+        const repoRoot = normalizePath(repository.rootUri.fsPath);
+        this.repositoryUiSubscriptions.get(repoRoot)?.dispose();
+        this.repositoryUiSubscriptions.set(repoRoot,
+            repository.ui.onDidChange(() => this.handleRepositoryUiChange(repository)));
     }
 
     private async handleRepositoryUiChange(repository: GitAPIRepository) {
         if (!this.autoChangeRepository || !repository.ui.selected) {
             return;
         }
+        // Following the SCM selection is meaningless when all repositories are
+        // shown side by side.
+        if (this.showRepositoryNodes()) {
+            return;
+        }
         const repoRoot = normalizePath(repository.rootUri.fsPath);
         const inWorkspace = getGitRepositoryFolders(this.gitApi).map(normalizePath).includes(repoRoot);
         if (!inWorkspace) {
-            const worktrees = this.repository ? await listWorktrees(this.repository) : [];
+            const active = this.activeComparison;
+            const worktrees = active ? await listWorktrees(active.repository) : [];
             if (!worktrees.some(wt => wt.path === repoRoot)) {
                 return;
             }
         }
-        if (repoRoot === this.repoRoot) {
+        if (repoRoot === this.activeComparison?.repoRoot) {
             return;
         }
         this.log(`SCM repository change detected - changing repository: ${repoRoot}`);
@@ -580,75 +1033,129 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
         return false;
     }
 
-    private updateExtraRepositoryWatcher(enabled: boolean) {
-        this.extraRepositoryWatcher?.dispose();
-        this.extraRepositoryWatcher = undefined;
-
-        if (!enabled) {
+    /**
+     * Watches repositories that the workspace-wide watcher does not cover:
+     * repositories outside the workspace, and git dirs that live outside their
+     * repository root (linked worktrees).
+     */
+    private addExtraRepositoryWatcher(comparison: RepositoryComparison) {
+        if (this.extraRepositoryWatchers.has(comparison.repoRoot)) {
             return;
         }
-
-        const watchers = [
-            workspace.createFileSystemWatcher(new RelativePattern(Uri.file(this.repoRoot), '**')),
-        ];
-        const normalizedGitDir = normalizePath(this.absGitDir);
-        if (normalizedGitDir !== this.repoRoot && !normalizedGitDir.startsWith(this.repoRoot + path.sep)) {
-            watchers.push(workspace.createFileSystemWatcher(new RelativePattern(Uri.file(this.absGitDir), '**')));
-        }
-
-        const subscriptions = watchers.map(watcher => {
+        const watchers: Disposable[] = [];
+        const subscriptions: Disposable[] = [];
+        const watch = (folder: string) => {
+            const watcher = workspace.createFileSystemWatcher(new RelativePattern(Uri.file(folder), '**'));
+            watchers.push(watcher);
             const onWorkspaceChange = anyEvent(watcher.onDidChange, watcher.onDidCreate, watcher.onDidDelete);
             const onRelevantWorkspaceChange = filterEvent(onWorkspaceChange, uri => this.isRelevantChange(uri));
-            return onRelevantWorkspaceChange(this.handleWorkspaceChange, this);
-        });
-        this.extraRepositoryWatcher = Disposable.from(...watchers, ...subscriptions);
+            subscriptions.push(onRelevantWorkspaceChange(this.handleWorkspaceChange, this));
+        };
+
+        if (comparison.isOutsideWorkspace) {
+            watch(comparison.repoRoot);
+        }
+        const normalizedGitDir = normalizePath(comparison.absGitDir);
+        if (normalizedGitDir !== comparison.repoRoot && !normalizedGitDir.startsWith(comparison.repoRoot + path.sep)) {
+            watch(comparison.absGitDir);
+        }
+
+        if (watchers.length === 0) {
+            return;
+        }
+        this.extraRepositoryWatchers.set(comparison.repoRoot, Disposable.from(...watchers, ...subscriptions));
+    }
+
+    private disposeExtraRepositoryWatchers() {
+        for (const watcher of this.extraRepositoryWatchers.values()) {
+            watcher.dispose();
+        }
+        this.extraRepositoryWatchers.clear();
+    }
+
+    /** Forgets a comparison and everything attached to it. */
+    private removeComparison(comparison: RepositoryComparison) {
+        this.invalidateComparisonCreations();
+        const repoRoot = comparison.repoRoot;
+        this.comparisons.delete(repoRoot);
+        this.extraRepositoryWatchers.get(repoRoot)?.dispose();
+        this.extraRepositoryWatchers.delete(repoRoot);
+        this.pendingRefreshRoots.delete(repoRoot);
+        this.reportedLoadErrors.delete(repoRoot);
+        for (const [alias, canonical] of [...this.rootAliases]) {
+            if (canonical === repoRoot) {
+                this.rootAliases.delete(alias);
+            }
+        }
+        if (this.activeComparison === comparison) {
+            this.activeComparison = undefined;
+        }
+    }
+
+    /** Drops comparisons for repositories that are no longer in the workspace. */
+    private pruneComparisons() {
+        const liveRoots = new Set(this.getRepositoryRoots().map(root => this.rootAliases.get(root) ?? root));
+        for (const [repoRoot, comparison] of [...this.comparisons]) {
+            // Repositories outside the workspace (linked worktrees) never appear
+            // in the workspace repository list, so keep them while they are active.
+            const keep = liveRoots.has(repoRoot) ||
+                (comparison === this.activeComparison && comparison.isOutsideWorkspace);
+            if (keep) {
+                continue;
+            }
+            this.removeComparison(comparison);
+        }
+    }
+
+    private async handleRepositoryClosed(repository: GitAPIRepository) {
+        // Also invalidates a creation that has not published its comparison yet.
+        this.invalidateComparisonCreations();
+        const repoRoot = normalizePath(repository.rootUri.fsPath);
+        this.repositoryUiSubscriptions.get(repoRoot)?.dispose();
+        this.repositoryUiSubscriptions.delete(repoRoot);
+        const comparison = this.getExistingComparison(repository.rootUri.fsPath);
+        if (comparison) {
+            this.removeComparison(comparison);
+        }
+        if (!this.showRepositoryNodes() && !this.activeComparison) {
+            const gitRepos = this.getRepositoryRoots(true);
+            if (gitRepos.length > 0) {
+                await this.changeRepository(gitRepos[0]);
+            } else {
+                await this.unsetRepository();
+            }
+            return;
+        }
+        this.updateViewState();
+        this.fireTreeDataChange();
     }
 
     private async handleWorkspaceFoldersChanged(e: WorkspaceFoldersChangeEvent) {
-        if (!this.multiRepositoryView) {
-            // If the folder got removed that was currently active in the diff,
-            // then pick an arbitrary new one.
-            for (var removedFolder of e.removed) {
-                if (normalizePath(removedFolder.uri.fsPath) === this.workspaceFolder) {
-                    const gitRepos = this.getCurrentRepositoryRoots(true);
-                    if (gitRepos.length > 0) {
-                        const newFolder = gitRepos[0];
-                        await this.changeRepository(newFolder);
-                    } else {
-                        await this.unsetRepository();
-                    }
-                }
-            }
-            // If no repository is selected but new folders were added,
-            // then pick an arbitrary new one.
-            if (!this.repository && e.added) {
-                const gitRepos = this.getCurrentRepositoryRoots(true);
-                if (gitRepos.length > 0) {
-                    const newFolder = gitRepos[0];
-                    await this.changeRepository(newFolder);
-                }
-            }
-            return;
+        if (e.removed.length > 0) {
+            this.invalidateComparisonCreations();
+            this.pruneComparisons();
         }
 
-        let removedAnyRepository = e.removed.length > 0;
-        for (var removedFolder of e.removed) {
-            const removedRoot = normalizePath(removedFolder.uri.fsPath);
-            const resolvedRoot = this.resolveRepositoryRootAlias(removedRoot);
-            this.repositoryStates.delete(resolvedRoot);
-            this.repositoryRootAliases.delete(removedRoot);
-            this.repositoryRootAliases.delete(resolvedRoot);
-            if (resolvedRoot === this.activeRepoRoot) {
-                this.repository = undefined;
-                this.activeRepoRoot = undefined;
+        if (!this.showRepositoryNodes()) {
+            // If the repository that was active got removed, or none was
+            // selected yet, then pick an arbitrary new one.
+            const active = this.activeComparison;
+            if (!active || !this.comparisons.has(active.repoRoot)) {
+                this.activeComparison = undefined;
+                const gitRepos = this.getRepositoryRoots(true);
+                if (gitRepos.length > 0) {
+                    await this.changeRepository(gitRepos[0]);
+                    return;
+                }
+                if (e.removed.length > 0) {
+                    await this.unsetRepository();
+                    return;
+                }
             }
         }
-        const gitRepos = this.getCurrentRepositoryRoots(true);
-        if (gitRepos.length === 0) {
-            await this.unsetRepository();
-            return;
-        }
-        if (removedAnyRepository || e.added.length > 0) {
+
+        if (e.removed.length > 0 || e.added.length > 0) {
+            this.updateViewState();
             this.fireTreeDataChange();
         }
     }
@@ -656,12 +1163,14 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
     private async handleChangeCheckboxState(e: TreeCheckboxChangeEvent<Element>) {
         for (let [element, state] of e.items) {
             if (element instanceof FileElement || element instanceof FolderElement) {
-                this.loadRepositoryState(element.repositoryRoot);
-                this.checkboxStates.set(element.dstAbsPath, {
+                const comparison = this.getExistingComparison(element.repositoryRoot);
+                if (!comparison) {
+                    continue;
+                }
+                comparison.checkboxStates.set(element.dstAbsPath, {
                     state: state,
                     timestamp: Date.now()
                 });
-                this.saveRepositoryState();
             }
         }
         if (this.hideCheckedFiles) {
@@ -685,21 +1194,12 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
         }
     }
 
-    private log(msg: string, error: Error | undefined=undefined) {
+    log(msg: string, error: Error | undefined=undefined) {
         if (error) {
             console.warn(msg, error);
             msg = `${msg}: ${error.message}`;
         }
         this.outputChannel.appendLine(msg);
-    }
-
-    private updateTreeRootFolder() {
-        const repoIsWorkspaceSubfolder = this.repoRoot.startsWith(this.workspaceFolder + path.sep);
-        if (this.treeRootIsRepo || repoIsWorkspaceSubfolder) {
-            this.treeRoot = this.repoRoot;
-        } else {
-            this.treeRoot = this.workspaceFolder;
-        }
     }
 
     private readConfig() {
@@ -727,54 +1227,22 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
         this.showDiffStats = config.get<boolean>('showDiffStats', false);
     }
 
-    private async getStoredBaseRef(): Promise<string | undefined> {
-        let baseRef = this.globalState.get<string>('baseRef_' + this.repoRoot);
-        if (baseRef) {
-            if (await this.isRefExisting(baseRef) || await this.isCommitExisting(baseRef)) {
-                this.log('Using stored base ref: ' + baseRef);
-            } else {
-                this.log('Not using non-existant stored base ref: ' + baseRef);
-                baseRef = undefined;
-            }
-        }
-        return baseRef;
-    }
-
-    private async isRefExisting(refName: string): Promise<boolean> {
-        const refs = await this.repository!.getRefs();
-        const exists = refs.some(ref => ref.name === refName);
-        return exists;
-    }
-
-    private async isCommitExisting(id: string): Promise<boolean> {
-        try {
-            await this.repository!.getCommit(id);
-            return true;
-        } catch {
-            return false;
-        }
-    }
-
-    private updateStoredBaseRef(baseRef: string) {
-        this.globalState.update('baseRef_' + this.repoRoot, baseRef);
-    }
-
     getTreeItem(element: Element): TreeItem {
-        this.loadRepositoryState(element.repositoryRoot);
+        const comparison = this.getExistingComparison(element.repositoryRoot);
         let checkboxState: TreeItemCheckboxState | undefined;
-        if (this.showCheckboxes) {
+        if (this.showCheckboxes && comparison) {
             if (element instanceof FileElement) {
-                const stateInfo = this.checkboxStates.get(element.dstAbsPath);
+                const stateInfo = comparison.checkboxStates.get(element.dstAbsPath);
                 checkboxState = stateInfo?.state ?? TreeItemCheckboxState.Unchecked;
             } else if (element instanceof FolderElement) {
                 // Compute folder state from children: checked if all children are checked
-                checkboxState = this.computeFolderCheckboxState(element);
+                checkboxState = this.computeFolderCheckboxState(comparison, element);
             }
         }
         const item = toTreeItem(element, this.openChangesOnSelect, this.iconsMinimal, this.iconStyle, this.showCollapsed, this.viewAsList, this.showDiffStats, checkboxState, this.asAbsolutePath);
         if (this.collapseGeneration > 0 && element instanceof FolderElement) {
             item.collapsibleState = TreeItemCollapsibleState.Collapsed;
-            item.id = element.dstAbsPath + '#c' + this.collapseGeneration;
+            item.id = getElementId(element) + '#c' + this.collapseGeneration;
         }
         return item;
     }
@@ -784,25 +1252,24 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
         return this.parentMap.get(id);
     }
 
-    private computeFolderCheckboxState(folder: FolderElement): TreeItemCheckboxState {
-        this.loadRepositoryState(folder.repositoryRoot);
+    private computeFolderCheckboxState(comparison: RepositoryComparison, folder: FolderElement): TreeItemCheckboxState {
         // Check if user explicitly set state on this folder
-        const explicitState = this.checkboxStates.get(folder.dstAbsPath);
+        const explicitState = comparison.checkboxStates.get(folder.dstAbsPath);
         if (explicitState) {
             return explicitState.state;
         }
-        
+
         // Otherwise derive from files: folder is checked only if ALL files under it are checked
-        const files = folder.useFilesOutsideTreeRoot ? this.filesOutsideTreeRoot : this.filesInsideTreeRoot;
+        const files = folder.useFilesOutsideTreeRoot ? comparison.filesOutsideTreeRoot : comparison.filesInsideTreeRoot;
         let hasFiles = false;
         let allChecked = true;
-        
+
         for (const [folderPath, fileEntries] of files.entries()) {
             // Check if this folder is under the target folder
             if (folderPath === folder.dstAbsPath || folderPath.startsWith(folder.dstAbsPath + path.sep)) {
                 for (const file of fileEntries) {
                     hasFiles = true;
-                    const stateInfo = this.checkboxStates.get(file.dstAbsPath);
+                    const stateInfo = comparison.checkboxStates.get(file.dstAbsPath);
                     if (!stateInfo || stateInfo.state !== TreeItemCheckboxState.Checked) {
                         allChecked = false;
                         break;
@@ -811,63 +1278,73 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
                 if (!allChecked) break;
             }
         }
-        
+
         return (hasFiles && allChecked) ? TreeItemCheckboxState.Checked : TreeItemCheckboxState.Unchecked;
+    }
+
+    private hasFiles(comparison: RepositoryComparison): boolean {
+        return comparison.filesInsideTreeRoot.size > 0 ||
+            (this.includeFilesOutsideWorkspaceFolderRoot && comparison.filesOutsideTreeRoot.size > 0);
     }
 
     async getChildren(element?: Element): Promise<Element[]> {
         if (!element) {
-            const gitRepos = this.getCurrentRepositoryRoots(true);
-            this.updateTreeTitle();
-            if (this.multiRepositoryView && gitRepos.length > 1) {
-                return gitRepos.map(repositoryRoot =>
-                    new RepositoryElement(repositoryRoot, path.basename(repositoryRoot), true));
-            }
-            if (!this.repository) {
-                return [];
-            }
-            if (!this.filesInsideTreeRoot) {
-                try {
-                    await this.updateDiff(false);
-                } catch (e: any) {
-                    // some error occured, ignore and try again next time
-                    this.log('Ignoring updateDiff() error during initial getChildren()', e);
-                    return [];
+            this.updateViewState();
+            if (this.showRepositoryNodes()) {
+                const roots = this.getRepositoryRoots(true);
+                // Repositories are labelled by folder name, which is not unique
+                // across checkouts, so disambiguate collisions with the parent.
+                const nameCounts = new Map<string, number>();
+                for (const root of roots) {
+                    const name = path.basename(root);
+                    nameCounts.set(name, (nameCounts.get(name) ?? 0) + 1);
                 }
+                return roots.map(root => {
+                    const name = path.basename(root);
+                    const ambiguous = (nameCounts.get(name) ?? 0) > 1;
+                    return new RepositoryElement(root, name, true,
+                        ambiguous ? path.basename(path.dirname(root)) : undefined);
+                });
             }
-            const hasFiles =
-                this.filesInsideTreeRoot.size > 0 ||
-                (this.includeFilesOutsideWorkspaceFolderRoot && this.filesOutsideTreeRoot.size > 0);
-
-            const children = [new RefElement(this.repoRoot, this.baseRef, hasFiles)];
-            // RefElement is the root, no parent to record
-            return children;
-        } else if (element instanceof RepositoryElement) {
-            if (!await this.hydrateRepository(element.repositoryRoot)) {
+            const comparison = this.activeComparison;
+            if (!comparison) {
                 return [];
             }
-            const hasFiles =
-                this.filesInsideTreeRoot.size > 0 ||
-                (this.includeFilesOutsideWorkspaceFolderRoot && this.filesOutsideTreeRoot.size > 0);
-            const children = [new RefElement(this.repoRoot, this.baseRef, hasFiles)];
+            try {
+                // Retries if a previous load failed.
+                await comparison.ensureLoaded();
+            } catch (e: any) {
+                this.log('Ignoring error during initial getChildren()', e);
+                return [];
+            }
+            // RefElement is the root, no parent to record
+            return [new RefElement(comparison.repoRoot, comparison.baseRef, this.hasFiles(comparison))];
+        } else if (element instanceof RepositoryElement) {
+            const comparison = await this.loadComparison(element.repositoryRoot);
+            if (!comparison) {
+                return [];
+            }
+            const children = [new RefElement(comparison.repoRoot, comparison.baseRef, this.hasFiles(comparison))];
             this.recordParents(element, children);
             return children;
         } else if (element instanceof RefElement) {
-            if (!await this.hydrateRepository(element.repositoryRoot)) {
+            const comparison = await this.loadComparison(element.repositoryRoot);
+            if (!comparison) {
                 return [];
             }
             const entries: Element[] = [];
-            if (this.includeFilesOutsideWorkspaceFolderRoot && this.filesOutsideTreeRoot.size > 0) {
-                entries.push(new RepoRootElement(this.repoRoot, this.repoRoot));
+            if (this.includeFilesOutsideWorkspaceFolderRoot && comparison.filesOutsideTreeRoot.size > 0) {
+                entries.push(new RepoRootElement(comparison.repoRoot, comparison.repoRoot));
             }
-            const children = entries.concat(this.getFileSystemEntries(this.treeRoot, false));
+            const children = entries.concat(this.getFileSystemEntries(comparison, comparison.treeRoot, false));
             this.recordParents(element, children);
             return children;
         } else if (element instanceof FolderElement) {
-            if (!await this.hydrateRepository(element.repositoryRoot)) {
+            const comparison = await this.loadComparison(element.repositoryRoot);
+            if (!comparison) {
                 return [];
             }
-            const children = this.getFileSystemEntries(element.dstAbsPath, element.useFilesOutsideTreeRoot);
+            const children = this.getFileSystemEntries(comparison, element.dstAbsPath, element.useFilesOutsideTreeRoot);
             this.recordParents(element, children);
             return children;
         }
@@ -884,351 +1361,80 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
         }
     }
 
-    private async updateRefs(baseRef?: string): Promise<void>
-    {
-        this.log('Updating refs');
-        try {
-            const headLastChecked = new Date();
-            const HEAD = await this.repository!.getHEAD();
-            // if detached HEAD, then .commit exists, otherwise only .name
-            const headName = HEAD.name;
-            const headCommit = HEAD.commit || await getBranchCommit(HEAD.name!, this.repository!);
-            if (baseRef) {
-                const exists = await this.isRefExisting(baseRef) || await this.isCommitExisting(baseRef);
-                if (!exists) {
-                    // happens when branch was deleted
-                    baseRef = undefined;
-                }
-            }
-            if (!baseRef) {
-                baseRef = await this.getStoredBaseRef();
-            }
-            if (!baseRef) {
-                baseRef = await getDefaultBranch(this.repository!, HEAD);
-            }
-            if (!baseRef) {
-                if (HEAD.name) {
-                    baseRef = HEAD.name;
-                } else {
-                    // detached HEAD and no default branch was found
-                    // pick an arbitrary ref as base, give preference to common refs
-                    const refs = await this.repository!.getRefs();
-                    const commonRefs = ['origin/main', 'main', 'origin/master', 'master'];
-                    const match = refs.find(ref => ref.name !== undefined && commonRefs.indexOf(ref.name) !== -1);
-                    if (match) {
-                        baseRef = match.name;
-                    } else if (refs.length > 0) {
-                        baseRef = refs[0].name;
-                    }
-                }
-            }
-            if (!baseRef) {
-                // this should never happen
-                throw new Error('Base ref could not be determined!');
-            }
-            const HEADref: string = (HEAD.name || HEAD.commit)!;
-            let mergeBase = baseRef;
-            if (!this.fullDiff && baseRef != HEAD.name) {
-                // determine merge base to create more sensible/compact diff
-                let mergeBaseResult: string | undefined;
-                try {
-                    mergeBaseResult = await this.repository!.getMergeBase(HEADref, baseRef);
-                } catch (e) {
-                    // sometimes the merge base cannot be determined
-                    // this can be the case with shallow clones but may have other reasons
-                }
-                if (!mergeBaseResult) {
-                    const gitApiRepo = this.gitApi.getRepository(Uri.file(this.repository!.root));
-                    if (gitApiRepo) {
-                        mergeBaseResult = await tryDeepenForMergeBase(
-                            this.repository!, gitApiRepo, HEADref, HEAD.name, baseRef,
-                            msg => this.log(msg));
-                    }
-                }
-                if (!mergeBaseResult) {
-                    throw new Error(
-                        `No merge base could be found between "${HEADref}" and "${baseRef}". ` +
-                        `This can happen with shallow clones that don't have enough depth. ` +
-                        `Try fetching more history, or switch the diff mode to "full".`);
-                }
-                mergeBase = mergeBaseResult;
-            }
-            if (this.headName !== headName) {
-                this.log(`HEAD ref updated: ${this.headName} -> ${headName}`);
-                this.checkboxStates.clear();
-            }
-            if (this.headCommit !== headCommit) {
-                this.log(`HEAD ref commit updated: ${this.headCommit} -> ${headCommit}`);
-            }
-            if (this.baseRef !== baseRef) {
-                this.log(`Base ref updated: ${this.baseRef} -> ${baseRef}`);
-            }
-            if (!this.fullDiff && this.mergeBase !== mergeBase) {
-                this.log(`Merge base updated: ${this.mergeBase} -> ${mergeBase}`);
-            }
-            this.headLastChecked = headLastChecked;
-            this.headName = headName;
-            this.headCommit = headCommit;
-            this.baseRef = baseRef;
-            this.mergeBase = mergeBase;
-            this.updateStoredBaseRef(baseRef);
-        } catch (e) {
-            throw e;
-        }
-    }
-
-    @throttle
-    private async updateDiff(fireChangeEvents: boolean) {
-        if (!this.baseRef) {
-            await this.updateRefs();
-        }
-
-        const filesInsideTreeRoot = new Map<FolderAbsPath, IDiffStatus[]>();
-        const filesOutsideTreeRoot = new Map<FolderAbsPath, IDiffStatus[]>();
-
-        const diff = await diffIndex(this.repository!, this.mergeBase, this.refreshIndex, this.findRenames, this.renameThreshold, this.omitUntrackedFiles, this.omitUnstagedChanges, this.showDiffStats);
-        const untrackedCount = diff.reduce((prev, cur, _) => prev + (cur.status === 'U' ? 1 : 0), 0);
-        this.log(`${diff.length} diff entries (${untrackedCount} untracked)`);
-
-        if (diff.length > MAX_DIFF_ENTRIES) {
-            const msg = `Too many changes to display (${diff.length}, limit is ${MAX_DIFF_ENTRIES}). Choose a closer base ref to reduce the number of changes.`;
-            this.log(msg);
-            window.showErrorMessage(msg);
-            this.filesInsideTreeRoot = new Map();
-            this.filesOutsideTreeRoot = new Map();
-            if (fireChangeEvents) {
-                this.fireTreeDataChange();
-            }
-            return;
-        }
-
-        const newFilePaths = new Set<string>();
-        // Collect files that need mtime checking for async batch processing
-        const filesToCheckMtime: Array<{filePath: string, stateInfo: CheckboxStateInfo}> = [];
-        
-        for (const entry of diff) {
-            const folder = path.dirname(entry.dstAbsPath);
-
-            const isInsideTreeRoot = folder === this.treeRoot || folder.startsWith(this.treeRoot + path.sep);
-            const files = isInsideTreeRoot ? filesInsideTreeRoot : filesOutsideTreeRoot;
-            const rootFolder = isInsideTreeRoot ? this.treeRoot : this.repoRoot;
-
-            if (files.size == 0) {
-                files.set(rootFolder, new Array());
-            }
-
-            // add this and all parent folders to the folder map
-            let currentFolder = folder
-            while (currentFolder != rootFolder) {
-                if (!files.has(currentFolder)) {
-                    files.set(currentFolder, new Array());
-                }
-                currentFolder = path.dirname(currentFolder)
-            }
-
-            const entries = files.get(folder)!;
-            entries.push(entry);
-
-            // Track new file paths
-            newFilePaths.add(entry.dstAbsPath);
-            
-            // Collect checked files for mtime checking to reset if modified after being checked
-            if (this.resetCheckboxOnFileChange) {
-                const stateInfo = this.checkboxStates.get(entry.dstAbsPath);
-                if (stateInfo && stateInfo.state === TreeItemCheckboxState.Checked) {
-                    filesToCheckMtime.push({filePath: entry.dstAbsPath, stateInfo});
-                }
-            }
-        }
-
-        // Check file modification times asynchronously in parallel
-        if (this.resetCheckboxOnFileChange && filesToCheckMtime.length > 0) {
-            const statPromises = filesToCheckMtime.map(async ({filePath, stateInfo}) => {
-                try {
-                    const stats = await fs.promises.stat(filePath);
-                    const fileMtime = stats.mtimeMs;
-                    
-                    // If file was modified after checkbox was checked, reset it
-                    if (fileMtime > stateInfo.timestamp) {
-                        return filePath;
-                    }
-                } catch (error: unknown) {
-                    // File might be deleted or inaccessible - this is expected in some cases
-                    const errorMessage = error instanceof Error ? error.message : String(error);
-                    this.log(`Could not stat file for checkbox reset check: ${filePath}: ${errorMessage}`);
-                }
-                return null;
-            });
-            
-            const pathsToReset = await Promise.all(statPromises);
-            const actualPathsToReset = pathsToReset.filter((filePath): filePath is string => filePath !== null);
-            actualPathsToReset.forEach(filePath => this.checkboxStates.delete(filePath));
-            
-            // Fire tree refresh to update checkbox UI
-            if (actualPathsToReset.length > 0) {
-                this.fireTreeDataChange();
-            }
-        }
-
-        // Clear checkbox state for files that no longer exist in the diff
-        const pathsToDelete: string[] = [];
-        for (const [filePath] of this.checkboxStates) {
-            if (!newFilePaths.has(filePath)) {
-                pathsToDelete.push(filePath);
-            }
-        }
-        for (const filePath of pathsToDelete) {
-            this.checkboxStates.delete(filePath);
-        }
-
-        let treeHasChanged = false;
-        if (fireChangeEvents) {
-            const hasChanged = (folderPath: string, insideTreeRoot: boolean) => {
-                const oldFiles = insideTreeRoot ? this.filesInsideTreeRoot : this.filesOutsideTreeRoot;
-                const newFiles = insideTreeRoot ? filesInsideTreeRoot : filesOutsideTreeRoot;
-                const oldItems = oldFiles.get(folderPath)!.map(f => `${f.status}|${f.dstAbsPath}`);
-                const newItems = newFiles.get(folderPath)!.map(f => `${f.status}|${f.dstAbsPath}`);
-                for (const {files, items} of [{files: oldFiles, items: oldItems},
-                                              {files: newFiles, items: newItems}]) {
-                    // add direct subdirectories to items list
-                    for (const folder of files.keys()) {
-                        if (path.dirname(folder) === folderPath) {
-                            items.push(folder);
-                        }
-                    }
-                }
-                return !sortedArraysEqual(oldItems, newItems);
-            }
-
-            const treeRootChanged = !this.filesInsideTreeRoot || !filesInsideTreeRoot.size !== !this.filesInsideTreeRoot.size;
-            const mustAddOrRemoveRepoRootElement = !this.filesOutsideTreeRoot || !filesOutsideTreeRoot.size !== !this.filesOutsideTreeRoot.size;
-            if (treeRootChanged || mustAddOrRemoveRepoRootElement) {
-                treeHasChanged = true;
-            } else {
-                for (const folder of filesInsideTreeRoot.keys()) {
-                    if (!this.filesInsideTreeRoot.has(folder) ||
-                            hasChanged(folder, true)) {
-                        treeHasChanged = true;
-                        break;
-                    }
-                }
-                if (!treeHasChanged) {
-                    for (const folder of filesOutsideTreeRoot.keys()) {
-                        if (!this.filesOutsideTreeRoot.has(folder) ||
-                                hasChanged(folder, false)) {
-                            treeHasChanged = true;
-                            break;
-                        }
-                    }
-                }
-            }
-        }
-
-        this.filesInsideTreeRoot = filesInsideTreeRoot;
-        this.filesOutsideTreeRoot = filesOutsideTreeRoot;
-
-        // Always refresh when sorting by recently modified in list view, as file mtimes may have changed
-        const needsRefreshForSorting = this.viewAsList && this.sortOrder === 'recentlyModified';
-        
-        if (fireChangeEvents && (treeHasChanged || needsRefreshForSorting || this.showDiffStats)) {
-            this.log('Refreshing tree')
-            this.fireTreeDataChange();
-        }
-    }
-
-    private async isHeadChanged() {
-        // Note that we can't rely on filesystem change notifications for .git/HEAD
-        // because the workspace root may be a subfolder of the repo root
-        // and change notifications are currently limited to workspace scope.
-        // See https://github.com/Microsoft/vscode/issues/3025.
-        const mtime = await getHeadModificationDate(this.absGitDir);
-        if (mtime > this.headLastChecked) {
-            return true;
-        }
-        // At this point we know that HEAD still points to the same symbolic ref or commit (if detached).
-        // If HEAD is not detached, check if the symbolic ref resolves to a different commit.
-        if (this.headName) {
-            // this.repository.getBranch() is not used here to avoid git invocation overhead
-            const headCommit = await getBranchCommit(this.headName, this.repository!);
-            if (this.headCommit !== headCommit) {
-                return true;
-            }
-        }
-        return false;
-    }
-
     private handleWorkspaceChange(uri: Uri) {
         if (!this.autoRefresh) {
             return
         }
-        const normPath = normalizePath(uri.fsPath);
-        const repoRoot = this.findRepositoryRootForPath(normPath);
-        if (!repoRoot) {
+        const comparison = this.findComparisonForPath(uri.fsPath);
+        if (!comparison) {
+            // Either the change is outside every known repository, or it belongs
+            // to a repository that has not been opened in the tree yet, in which
+            // case there is no diff to refresh.
             this.log(`Ignoring change outside of repositories: ${uri.fsPath}`)
             return;
         }
-        this.pendingRefreshRepositories.set(repoRoot, uri);
+        this.pendingRefreshRoots.add(comparison.repoRoot);
         if (this.pendingRefreshTimer) {
             clearTimeout(this.pendingRefreshTimer);
         }
         this.pendingRefreshTimer = setTimeout(() => {
             this.pendingRefreshTimer = undefined;
-            this.refreshPendingRepositories();
+            void this.processPendingRefreshes();
         }, 2000);
     }
 
-    private async refreshPendingRepositories() {
-        const repositoryEntries = [...this.pendingRefreshRepositories.entries()];
-        this.pendingRefreshRepositories.clear();
-        for (const [repoRoot, uri] of repositoryEntries) {
-            await this.refreshRepositoryForWorkspaceChange(repoRoot, uri);
+    /**
+     * Refreshes all repositories with pending changes. Entries are only removed
+     * once they are actually processed, and a second invocation while one is
+     * already running is a no-op, so a burst of changes while the window is in
+     * the background cannot drop a repository's only pending refresh.
+     */
+    private async processPendingRefreshes() {
+        if (this.refreshInProgress) {
+            return;
+        }
+        this.refreshInProgress = true;
+        try {
+            while (this.pendingRefreshRoots.size > 0 && !this.disposed) {
+                if (!window.state.focused || !this.treeView.visible) {
+                    await this.waitUntilFocusedAndVisible();
+                    continue;
+                }
+                const repoRoot = this.pendingRefreshRoots.values().next().value as FolderAbsPath;
+                this.pendingRefreshRoots.delete(repoRoot);
+                const comparison = this.comparisons.get(repoRoot);
+                if (!comparison) {
+                    continue;
+                }
+                this.log(`Relevant workspace change detected: ${repoRoot}`)
+                await this.refreshComparison(comparison);
+            }
+        } finally {
+            this.refreshInProgress = false;
         }
     }
 
-    private async refreshRepositoryForWorkspaceChange(repoRoot: string, uri: Uri) {
-        const normPath = normalizePath(uri.fsPath);
-        if (!await this.useRepository(repoRoot)) {
-            this.log(`Ignoring change outside of repositories: ${uri.fsPath}`)
-            return;
-        }
-        // ignore changes outside of repo root
-        //  e.g. "c:\Users\..\AppData\Roaming\Code - Insiders\User\globalStorage"
-        const normalizedGitDir = normalizePath(this.absGitDir);
-        if (!normPath.startsWith(this.repoRoot + path.sep) && !normPath.startsWith(normalizedGitDir + path.sep)) {
-            this.log(`Ignoring change outside of repository: ${uri.fsPath}`)
-            return
-        }
-        if (!window.state.focused || !this.treeView.visible) {
-            if (this.isPaused) {
-                return;
-            }
-            this.isPaused = true;
-            const onDidFocusWindow = filterEvent(window.onDidChangeWindowState, e => e.focused);
-            const onDidBecomeVisible = filterEvent(this.treeView.onDidChangeVisibility, e => e.visible);
-            const onDidFocusWindowOrBecomeVisible = anyEvent<any>(onDidFocusWindow, onDidBecomeVisible);
-            await eventToPromise(onDidFocusWindowOrBecomeVisible);
-            this.isPaused = false;
-            await this.refreshRepositoryForWorkspaceChange(repoRoot, uri);
-            return;
-        }
-        this.log(`Relevant workspace change detected: ${uri.fsPath}`)
-        if (await this.isHeadChanged()) {
-            // make sure merge base is updated when switching branches
-            try {
-                await this.updateRefs(this.baseRef);
-            } catch (e: any) {
-                // some error occured, ignore and try again next time
-                this.log('Ignoring updateRefs() error during handleWorkspaceChange()', e);
-                return;
-            }
-        }
+    private async waitUntilFocusedAndVisible(): Promise<void> {
+        const onDidFocusWindow = filterEvent(window.onDidChangeWindowState, e => e.focused);
+        const onDidBecomeVisible = filterEvent(this.treeView.onDidChangeVisibility, e => e.visible);
+        const onDidFocusWindowOrBecomeVisible = anyEvent<any>(onDidFocusWindow, onDidBecomeVisible);
+        await eventToPromise(onDidFocusWindowOrBecomeVisible);
+    }
+
+    private async refreshComparison(comparison: RepositoryComparison, showErrors=false) {
         try {
-            await this.updateDiff(true);
-            this.saveRepositoryState();
+            if (await comparison.isHeadChanged()) {
+                // make sure merge base is updated when switching branches
+                await comparison.updateRefs(comparison.baseRef);
+            }
+            await comparison.updateDiff(true);
         } catch (e: any) {
             // some error occured, ignore and try again next time
-            this.log('Ignoring updateDiff() error during handleWorkspaceChange()', e);
-            return;
+            let msg = 'Updating the git tree failed';
+            this.log(msg, e);
+            if (showErrors) {
+                window.showErrorMessage(`${msg}: ${e.message}`);
+            }
         }
     }
 
@@ -1274,10 +1480,16 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
             oldShowDiffStats != this.showDiffStats) {
 
             if (oldMultiRepositoryView != this.multiRepositoryView) {
-                this.repositoryStates.clear();
-                this.repositoryRootAliases.clear();
-                const gitRepos = this.getCurrentRepositoryRoots(true);
-                if (!this.multiRepositoryView || gitRepos.length === 1) {
+                // The layout changed, start from a clean slate.
+                this.invalidateComparisonCreations();
+                this.activeComparison = undefined;
+                this.comparisons.clear();
+                this.rootAliases.clear();
+                this.reportedLoadErrors.clear();
+                this.pendingRefreshRoots.clear();
+                this.disposeExtraRepositoryWatchers();
+                if (!this.showRepositoryNodes()) {
+                    const gitRepos = this.getRepositoryRoots(true);
                     if (gitRepos.length > 0) {
                         await this.changeRepository(gitRepos[0]);
                     } else {
@@ -1285,89 +1497,83 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
                     }
                     return;
                 }
+                this.updateViewState();
                 this.fireTreeDataChange();
                 return;
             }
 
-            const repositoriesToUpdate = this.multiRepositoryView
-                ? this.getCurrentRepositoryRoots(true)
-                : (this.repository ? [this.repoRoot] : []);
+            const needsReload =
+                oldFullDiff != this.fullDiff ||
+                oldFindRenames != this.findRenames ||
+                oldRenameThreshold != this.renameThreshold ||
+                (!oldAutoRefresh && this.autoRefresh) ||
+                (!oldRefreshIndex && this.refreshIndex) ||
+                oldOmitUntrackedFiles != this.omitUntrackedFiles ||
+                oldOmitUnstagedChanges != this.omitUnstagedChanges ||
+                oldShowDiffStats != this.showDiffStats;
 
-            for (const repositoryRoot of repositoriesToUpdate) {
-                if (!await this.hydrateRepository(repositoryRoot)) {
+            // Only repositories that have already been loaded need updating.
+            // The rest pick up the new settings when they are first expanded.
+            for (const comparison of [...this.comparisons.values()]) {
+                const treeRootChanged = oldTreeRootIsRepo != this.treeRootIsRepo &&
+                    comparison.updateTreeRootFolder();
+                if (!needsReload && !treeRootChanged) {
                     continue;
                 }
-
-                const oldTreeRoot = this.treeRoot;
-                if (oldTreeRootIsRepo != this.treeRootIsRepo) {
-                    this.updateTreeRootFolder();
+                try {
+                    await comparison.updateRefs(comparison.baseRef);
+                    await comparison.updateDiff(false);
+                } catch (e: any) {
+                    let msg = 'Updating the git tree failed';
+                    this.log(msg, e);
+                    window.showErrorMessage(`${msg}: ${e.message}`);
+                    // clear the tree as it would be confusing to display stale data under the new settings
+                    comparison.clearFiles();
                 }
-
-                if (oldFullDiff != this.fullDiff ||
-                    oldFindRenames != this.findRenames ||
-                    oldRenameThreshold != this.renameThreshold ||
-                    oldTreeRoot != this.treeRoot ||
-                    (!oldAutoRefresh && this.autoRefresh) ||
-                    (!oldRefreshIndex && this.refreshIndex) ||
-                    oldOmitUntrackedFiles != this.omitUntrackedFiles ||
-                    oldOmitUnstagedChanges != this.omitUnstagedChanges ||
-                    oldShowDiffStats != this.showDiffStats) {
-                    try {
-                        await this.updateRefs(this.baseRef);
-                        await this.updateDiff(false);
-                    } catch (e: any) {
-                        let msg = 'Updating the git tree failed';
-                        this.log(msg, e);
-                        window.showErrorMessage(`${msg}: ${e.message}`);
-                        // clear the tree as it would be confusing to display stale data under the new settings
-                        this.filesInsideTreeRoot = new Map();
-                        this.filesOutsideTreeRoot = new Map();
-                    }
-                }
-                this.saveRepositoryState();
             }
+            this.updateViewState();
             this.fireTreeDataChange();
         }
     }
 
-    private matchesFilter(filePath: string, relPathBase: string): boolean {
-        if (!this.searchFilter) {
+    private matchesFilter(comparison: RepositoryComparison, filePath: string, relPathBase: string): boolean {
+        if (!comparison.searchFilter) {
             return true;
         }
         const fileName = path.basename(filePath);
         const relativePath = path.relative(relPathBase, filePath);
-        const searchLower = this.searchFilter.toLowerCase();
+        const searchLower = comparison.searchFilter.toLowerCase();
         return fileName.toLowerCase().includes(searchLower) ||
                relativePath.toLowerCase().includes(searchLower);
     }
 
-    private isFileCheckboxChecked(dstAbsPath: string): boolean {
-        const stateInfo = this.checkboxStates.get(dstAbsPath);
+    private isFileCheckboxChecked(comparison: RepositoryComparison, dstAbsPath: string): boolean {
+        const stateInfo = comparison.checkboxStates.get(dstAbsPath);
         return stateInfo?.state === TreeItemCheckboxState.Checked;
     }
 
     /** Whether this file row should appear in the tree (search + optional hide-checked). */
-    private fileVisibleInTree(dstAbsPath: string, relPathBase: string): boolean {
-        if (!this.matchesFilter(dstAbsPath, relPathBase)) {
+    private fileVisibleInTree(comparison: RepositoryComparison, dstAbsPath: string, relPathBase: string): boolean {
+        if (!this.matchesFilter(comparison, dstAbsPath, relPathBase)) {
             return false;
         }
-        if (this.hideCheckedFiles && this.isFileCheckboxChecked(dstAbsPath)) {
+        if (this.hideCheckedFiles && this.isFileCheckboxChecked(comparison, dstAbsPath)) {
             return false;
         }
         return true;
     }
 
-    private folderHasMatchingFiles(folder: string, useFilesOutsideTreeRoot: boolean): boolean {
-        if (!this.searchFilter && !this.hideCheckedFiles) {
+    private folderHasMatchingFiles(comparison: RepositoryComparison, folder: string, useFilesOutsideTreeRoot: boolean): boolean {
+        if (!comparison.searchFilter && !this.hideCheckedFiles) {
             return true;
         }
-        const files = useFilesOutsideTreeRoot ? this.filesOutsideTreeRoot : this.filesInsideTreeRoot;
-        const relPathBase = useFilesOutsideTreeRoot ? this.repoRoot : this.treeRoot;
+        const files = useFilesOutsideTreeRoot ? comparison.filesOutsideTreeRoot : comparison.filesInsideTreeRoot;
+        const relPathBase = useFilesOutsideTreeRoot ? comparison.repoRoot : comparison.treeRoot;
 
         for (const [folderPath, fileEntries] of files.entries()) {
             if (folderPath === folder || folderPath.startsWith(folder + path.sep)) {
                 for (const file of fileEntries) {
-                    if (this.fileVisibleInTree(file.dstAbsPath, relPathBase)) {
+                    if (this.fileVisibleInTree(comparison, file.dstAbsPath, relPathBase)) {
                         return true;
                     }
                 }
@@ -1376,10 +1582,10 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
         return false;
     }
 
-    private getFileSystemEntries(folder: string, useFilesOutsideTreeRoot: boolean): FileSystemElement[] {
+    private getFileSystemEntries(comparison: RepositoryComparison, folder: string, useFilesOutsideTreeRoot: boolean): FileSystemElement[] {
         const entries: FileSystemElement[] = [];
-        const files = useFilesOutsideTreeRoot ? this.filesOutsideTreeRoot : this.filesInsideTreeRoot;
-        const relPathBase = useFilesOutsideTreeRoot ? this.repoRoot : this.treeRoot;
+        const files = useFilesOutsideTreeRoot ? comparison.filesOutsideTreeRoot : comparison.filesInsideTreeRoot;
+        const relPathBase = useFilesOutsideTreeRoot ? comparison.repoRoot : comparison.treeRoot;
 
         if (this.viewAsList) {
             // add files of direct and nested subfolders
@@ -1394,9 +1600,9 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
             for (const folder2 of folders) {
                 const fileEntries = files.get(folder2)!;
                 for (const file of fileEntries) {
-                    if (this.fileVisibleInTree(file.dstAbsPath, relPathBase)) {
+                    if (this.fileVisibleInTree(comparison, file.dstAbsPath, relPathBase)) {
                         const dstRelPath = path.relative(relPathBase, file.dstAbsPath);
-                        entries.push(new FileElement(file.srcAbsPath, file.dstAbsPath, dstRelPath, file.status, file.isSubmodule, this.repoRoot, file.stats));
+                        entries.push(new FileElement(file.srcAbsPath, file.dstAbsPath, dstRelPath, file.status, file.isSubmodule, comparison.repoRoot, file.stats));
                     }
                 }
             }
@@ -1404,7 +1610,7 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
             // add direct subfolders and apply compaction
             for (const folder2 of files.keys()) {
                 if (path.dirname(folder2) === folder) {
-                    if (!this.folderHasMatchingFiles(folder2, useFilesOutsideTreeRoot)) {
+                    if (!this.folderHasMatchingFiles(comparison, folder2, useFilesOutsideTreeRoot)) {
                         continue;
                     }
                     let compactedPath = folder2;
@@ -1433,7 +1639,7 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
 
                     const label = path.relative(folder, compactedPath);
                     entries.push(new FolderElement(
-                        label, compactedPath, useFilesOutsideTreeRoot, this.repoRoot));
+                        label, compactedPath, useFilesOutsideTreeRoot, comparison.repoRoot));
                 }
             }
             entries.sort((a, b) => a.label.split(path.sep, 1)[0].localeCompare(b.label.split(path.sep, 1)[0]));
@@ -1441,10 +1647,10 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
             // add direct subfolders
             for (const folder2 of files.keys()) {
                 if (path.dirname(folder2) === folder) {
-                    if (this.folderHasMatchingFiles(folder2, useFilesOutsideTreeRoot)) {
+                    if (this.folderHasMatchingFiles(comparison, folder2, useFilesOutsideTreeRoot)) {
                         const label = path.basename(folder2);
                         entries.push(new FolderElement(
-                            label, folder2, useFilesOutsideTreeRoot, this.repoRoot));
+                            label, folder2, useFilesOutsideTreeRoot, comparison.repoRoot));
                     }
                 }
             }
@@ -1457,9 +1663,9 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
         // there are no files within treeRoot, therefore, this is guarded
         if (fileEntries) {
             for (const file of fileEntries) {
-                if (this.fileVisibleInTree(file.dstAbsPath, relPathBase)) {
+                if (this.fileVisibleInTree(comparison, file.dstAbsPath, relPathBase)) {
                     const dstRelPath = path.relative(relPathBase, file.dstAbsPath);
-                    entries.push(new FileElement(file.srcAbsPath, file.dstAbsPath, dstRelPath, file.status, file.isSubmodule, this.repoRoot, file.stats));
+                    entries.push(new FileElement(file.srcAbsPath, file.dstAbsPath, dstRelPath, file.status, file.isSubmodule, comparison.repoRoot, file.stats));
                 }
             }
         }
@@ -1526,46 +1732,40 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
         entries.push(...folderElements, ...fileElements);
     }
 
-    private getDiffStatus(fileEntry?: FileElement): IDiffStatus | undefined {
+    /**
+     * Resolves the diff status of a file together with the repository it
+     * belongs to. Returns undefined when the file is not part of any loaded
+     * comparison, so a command can never act on another repository's state.
+     */
+    private resolveFile(fileEntry?: FileElement): { comparison: RepositoryComparison, status: IDiffStatus } | undefined {
         if (fileEntry) {
-            this.loadRepositoryState(fileEntry.repositoryRoot);
-            return fileEntry;
+            const comparison = this.getExistingComparison(fileEntry.repositoryRoot);
+            return comparison ? { comparison, status: fileEntry } : undefined;
         }
         const uri = window.activeTextEditor && window.activeTextEditor.document.uri;
         if (!uri || uri.scheme !== 'file') {
             return;
         }
-        const dstAbsPath = uri.fsPath;
-        const repoRoot = this.findRepositoryRootForPath(dstAbsPath);
-        if (repoRoot) {
-            this.loadRepositoryState(repoRoot);
+        const comparison = this.findComparisonForPath(uri.fsPath);
+        if (!comparison) {
+            return;
         }
-        const folder = path.dirname(dstAbsPath);
-        const isInsideTreeRoot = folder === this.treeRoot || folder.startsWith(this.treeRoot + path.sep);
-        const files = isInsideTreeRoot ? this.filesInsideTreeRoot : this.filesOutsideTreeRoot;
-        const diffStatus = files.get(folder)?.find(file => file.dstAbsPath === dstAbsPath);
-        return diffStatus;
-    }
-
-    private findRepositoryRootForPath(absPath: string): string | undefined {
-        const normPath = normalizePath(absPath);
-        const repoRoots = this.getCurrentRepositoryRoots()
-            .filter(repoRoot => normPath === repoRoot || normPath.startsWith(repoRoot + path.sep))
-            .sort((a, b) => b.length - a.length);
-        return repoRoots[0];
+        const status = comparison.findFile(uri.fsPath);
+        return status ? { comparison, status } : undefined;
     }
 
     async openChanges(fileEntry?: FileElement) {
-        const diffStatus = this.getDiffStatus(fileEntry);
-        if (!diffStatus) {
+        const resolved = this.resolveFile(fileEntry);
+        if (!resolved) {
             return;
         }
-        await this.doOpenChanges(diffStatus.srcAbsPath, diffStatus.dstAbsPath, diffStatus.status);
+        const { comparison, status } = resolved;
+        await this.doOpenChanges(comparison, status.srcAbsPath, status.dstAbsPath, status.status);
     }
 
-    async doOpenChanges(srcAbsPath: string, dstAbsPath: string, status: StatusCode, preview=true) {
+    async doOpenChanges(comparison: RepositoryComparison, srcAbsPath: string, dstAbsPath: string, status: StatusCode, preview=true) {
         const right = Uri.file(dstAbsPath);
-        const left = this.gitApi.toGitUri(Uri.file(srcAbsPath), this.mergeBase);
+        const left = this.gitApi.toGitUri(Uri.file(srcAbsPath), comparison.mergeBase);
 
         if (status === 'U' || status === 'A') {
             return commands.executeCommand('vscode.open', right);
@@ -1583,27 +1783,28 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
     }
 
     async openAllChanges(entry: RefElement | RepoRootElement | FolderElement | RepositoryElement | undefined) {
-        if (!await this.ensureRepositoryForCommand(entry)) {
+        const comparison = await this.resolveComparison(entry);
+        if (!comparison) {
             return;
         }
         const withinFolder = entry instanceof FolderElement ? entry.dstAbsPath : undefined;
-        for (const file of this.iterFiles(withinFolder)) {
-            this.doOpenChanges(file.srcAbsPath, file.dstAbsPath, file.status, false);
+        for (const file of comparison.iterFiles(withinFolder)) {
+            this.doOpenChanges(comparison, file.srcAbsPath, file.dstAbsPath, file.status, false);
         }
     }
 
     async openFile(fileEntries: FileElement[]) {
         for (const fileEntry of fileEntries) {
-            const diffStatus = this.getDiffStatus(fileEntry);
-            if (diffStatus) {
-                await this.doOpenFile(diffStatus.dstAbsPath, diffStatus.status);
+            const resolved = this.resolveFile(fileEntry);
+            if (resolved) {
+                await this.doOpenFile(resolved.comparison, resolved.status.dstAbsPath, resolved.status.status);
             }
         }
     }
 
-    async doOpenFile(dstAbsPath: string, status: StatusCode, preview=false) {
+    async doOpenFile(comparison: RepositoryComparison, dstAbsPath: string, status: StatusCode, preview=false) {
         const right = Uri.file(dstAbsPath);
-        const left = this.gitApi.toGitUri(right, this.mergeBase);
+        const left = this.gitApi.toGitUri(right, comparison.mergeBase);
         const uri = status === 'D' ? left : right;
         const options: TextDocumentShowOptions = {
             preview: preview
@@ -1612,38 +1813,37 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
     }
 
     async discardChanges(entries: (FileElement | FolderElement)[]) {
-        const statusesByRepository = new Map<string, IDiffStatus[]>();
+        const statusesByRepository = new Map<RepositoryComparison, IDiffStatus[]>();
         for (const entry of entries) {
-            this.loadRepositoryState(entry.repositoryRoot);
-            let statuses = statusesByRepository.get(entry.repositoryRoot);
+            const comparison = this.getExistingComparison(entry.repositoryRoot);
+            if (!comparison) {
+                continue;
+            }
+            let statuses = statusesByRepository.get(comparison);
             if (!statuses) {
                 statuses = [];
-                statusesByRepository.set(entry.repositoryRoot, statuses);
+                statusesByRepository.set(comparison, statuses);
             }
             if (entry instanceof FolderElement) {
-                statuses.push(...this.iterFiles(entry.dstAbsPath));
+                statuses.push(...comparison.iterFiles(entry.dstAbsPath));
             } else {
-                const diffStatus = this.getDiffStatus(entry);
-                if (diffStatus) {
-                    statuses.push(diffStatus);
-                }
+                statuses.push(entry);
             }
         }
-        for (const [repositoryRoot, statuses] of statusesByRepository) {
-            this.loadRepositoryState(repositoryRoot);
-            await this.doDiscardChanges(statuses);
+        for (const [comparison, statuses] of statusesByRepository) {
+            await this.doDiscardChanges(comparison, statuses);
         }
     }
 
     async discardAllChanges(entry?: RefElement | RepositoryElement) {
-        if (!await this.ensureRepositoryForCommand(entry)) {
+        const comparison = await this.resolveComparison(entry);
+        if (!comparison) {
             return;
         }
-        const statuses = [...this.iterFiles()];
-        await this.doDiscardChanges(statuses);
+        await this.doDiscardChanges(comparison, [...comparison.iterFiles()]);
     }
 
-    async doDiscardChanges(statuses: IDiffStatus[]) {
+    async doDiscardChanges(comparison: RepositoryComparison, statuses: IDiffStatus[]) {
         if (statuses.length === 0) {
             return;
         }
@@ -1663,7 +1863,7 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
                     fs.unlinkSync(diffStatus.dstAbsPath);
                 });
             } else if (diffStatus.status === 'A') {
-                const dirty = await hasUncommittedChanges(this.repository!, diffStatus.dstAbsPath);
+                const dirty = await hasUncommittedChanges(comparison.repository, diffStatus.dstAbsPath);
                 let msg = `Do you really want to delete ${filename}?`;
                 if (dirty) {
                     uncommittedChanges.push(filename);
@@ -1671,12 +1871,12 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
                 }
                 prompts.push([msg, 'Delete File']);
                 actions.push(async () => {
-                    await rmFile(this.repository!, diffStatus.dstAbsPath);
+                    await rmFile(comparison.repository, diffStatus.dstAbsPath);
                 });
             } else if (diffStatus.status === 'M' || diffStatus.status === 'D') {
-                let msg = `Do you really want to restore ${filename} with the contents from ${this.baseRef}?`;
+                let msg = `Do you really want to restore ${filename} with the contents from ${comparison.baseRef}?`;
                 if (diffStatus.status !== 'D') {
-                    const dirty = await hasUncommittedChanges(this.repository!, diffStatus.dstAbsPath);
+                    const dirty = await hasUncommittedChanges(comparison.repository, diffStatus.dstAbsPath);
                     if (dirty) {
                         uncommittedChanges.push(filename);
                         msg = `${msg}\nThis file has UNCOMMITTED changes which will be FOREVER LOST!`;
@@ -1684,7 +1884,7 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
                 }
                 prompts.push([msg, 'Restore File']);
                 actions.push(async () => {
-                    await this.repository!.checkout(this.mergeBase, [diffStatus.dstAbsPath]);
+                    await comparison.repository.checkout(comparison.mergeBase, [diffStatus.dstAbsPath]);
                 });
             } else if (diffStatus.status === 'R') {
                 const srcFolder = path.dirname(diffStatus.srcAbsPath);
@@ -1698,20 +1898,20 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
                     dstFile = path.basename(diffStatus.dstAbsPath);
                 } else {
                     verb = 'move';
-                    const relPathBase = this.treeRoot;
+                    const relPathBase = comparison.treeRoot;
                     srcFile = path.relative(relPathBase, diffStatus.srcAbsPath);
                     dstFile = path.relative(relPathBase, diffStatus.dstAbsPath);
                 }
-                let msg = `Do you really want to ${verb} ${srcFile} to ${dstFile} and restore contents from ${this.baseRef}?`;
-                const dirty = await hasUncommittedChanges(this.repository!, diffStatus.dstAbsPath);
+                let msg = `Do you really want to ${verb} ${srcFile} to ${dstFile} and restore contents from ${comparison.baseRef}?`;
+                const dirty = await hasUncommittedChanges(comparison.repository, diffStatus.dstAbsPath);
                 if (dirty) {
                     uncommittedChanges.push(filename);
                     msg = `${msg}\nThis file has UNCOMMITTED changes which will be FOREVER LOST!`;
                 }
                 prompts.push([msg, 'Restore File']);
                 actions.push(async () => {
-                    await rmFile(this.repository!, diffStatus.dstAbsPath);
-                    await this.repository!.checkout(this.mergeBase, [diffStatus.srcAbsPath]);
+                    await rmFile(comparison.repository, diffStatus.dstAbsPath);
+                    await comparison.repository.checkout(comparison.mergeBase, [diffStatus.srcAbsPath]);
                 });
             } else {
                 window.showInformationMessage(
@@ -1750,45 +1950,28 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
     }
 
     async openChangedFiles(entry: RefElement | RepoRootElement | FolderElement | RepositoryElement | undefined) {
-        if (!await this.ensureRepositoryForCommand(entry)) {
+        const comparison = await this.resolveComparison(entry);
+        if (!comparison) {
             return;
         }
         const withinFolder = entry instanceof FolderElement ? entry.dstAbsPath : undefined;
-        for (const file of this.iterFiles(withinFolder)) {
+        for (const file of comparison.iterFiles(withinFolder)) {
             if (file.status == 'D') {
                 continue;
             }
-            this.doOpenFile(file.dstAbsPath, file.status, false);
-        }
-    }
-
-    *iterFiles(withinFolder: string | undefined = undefined) {
-        for (let filesMap of [this.filesInsideTreeRoot, this.filesOutsideTreeRoot]) {
-            for (let [folder, files] of filesMap.entries()) {
-                if (withinFolder && !folder.startsWith(withinFolder)) {
-                    continue;
-                }
-                for (let file of files) {
-                    if (!file.isSubmodule) {
-                        yield file;
-                    }
-                }
-            }
+            this.doOpenFile(comparison, file.dstAbsPath, file.status, false);
         }
     }
 
     async promptChangeBase(entry?: RefElement | RepositoryElement) {
-        if (!await this.ensureRepositoryForCommand(entry)) {
-            window.showErrorMessage('No repository selected');
-            return;
-        }
-        if (!this.repository) {
+        const comparison = await this.resolveComparison(entry);
+        if (!comparison) {
             window.showErrorMessage('No repository selected');
             return;
         }
         const commit = new ChangeBaseCommitItem();
         const sortOrder = workspace.getConfiguration(NAMESPACE).get<'alphabetically' | 'committerdate'>('refSortOrder', 'committerdate');
-        const refs = (await this.repository.getRefs({ sort: sortOrder })).filter(ref => ref.name);
+        const refs = (await comparison.repository.getRefs({ sort: sortOrder })).filter(ref => ref.name);
         const heads = refs.filter(ref => ref.type === RefType.Head).map(ref => new ChangeBaseRefItem(ref));
         const tags = refs.filter(ref => ref.type === RefType.Tag).map(ref => new ChangeBaseTagItem(ref));
         const remoteHeads = refs.filter(ref => ref.type === RefType.RemoteHead).map(ref => new ChangeBaseRemoteHeadItem(ref));
@@ -1818,12 +2001,12 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
             throw new Error("unsupported item type");
         }
 
-        if (this.baseRef === baseRef) {
+        if (comparison.baseRef === baseRef) {
             return;
         }
         window.withProgress({ location: ProgressLocation.Window, title: 'Updating Tree Base' }, async _ => {
             try {
-                await this.updateRefs(baseRef);
+                await comparison.updateRefs(baseRef);
             } catch (e: any) {
                 let msg = 'Updating the git tree base failed';
                 this.log(msg, e);
@@ -1831,16 +2014,13 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
                 return;
             }
             try {
-                await this.updateDiff(false);
-                this.saveRepositoryState();
+                await comparison.updateDiff(false);
             } catch (e: any) {
                 let msg = 'Updating the git tree failed';
                 this.log(msg, e);
                 window.showErrorMessage(`${msg}: ${e.message}`);
                 // clear the tree as it would be confusing to display the old tree under the new base
-                this.filesInsideTreeRoot = new Map();
-                this.filesOutsideTreeRoot = new Map();
-                this.saveRepositoryState();
+                comparison.clearFiles();
             }
             this.log('Refreshing tree');
             this.fireTreeDataChange();
@@ -1848,16 +2028,13 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
     }
 
     async compareGitHubPullRequest(entry?: RefElement | RepositoryElement) {
-        if (!await this.ensureRepositoryForCommand(entry)) {
-            window.showErrorMessage('No repository selected');
-            return;
-        }
-        if (!this.repository) {
+        const comparison = await this.resolveComparison(entry);
+        if (!comparison) {
             window.showErrorMessage('No repository selected');
             return;
         }
 
-        const repository = this.repository;
+        const repository = comparison.repository;
 
         // Check for uncommitted changes (ignoring untracked files)
         try {
@@ -2019,9 +2196,8 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
                 try {
                     const originBaseRef = `origin/${baseRef}`;
                     this.log(`Updating base to: ${originBaseRef}`);
-                    await this.updateRefs(originBaseRef);
-                    await this.updateDiff(false);
-                    this.saveRepositoryState();
+                    await comparison.updateRefs(originBaseRef);
+                    await comparison.updateDiff(false);
                     this.log('Refreshing tree');
                     this.fireTreeDataChange();
                     window.showInformationMessage(`Now comparing PR #${prNumber}: ${pr.title}`);
@@ -2040,51 +2216,40 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
     }
 
     async manualRefresh(entry?: RefElement | RepositoryElement) {
-        if (!await this.ensureRepositoryForCommand(entry)) {
+        const repositoryRoot = await this.resolveRepositoryRoot(entry);
+        if (!repositoryRoot) {
             window.showErrorMessage('No repository selected');
             return;
         }
-        window.withProgress({ location: ProgressLocation.Window, title: 'Updating Tree' }, async _ => {
-            await this.refreshActiveRepository();
+        await window.withProgress({ location: ProgressLocation.Window, title: 'Updating Tree' }, async _ => {
+            await this.refreshOrLoadComparison(repositoryRoot);
         });
+    }
+
+    private async refreshOrLoadComparison(repositoryRoot: string): Promise<void> {
+        const comparison = this.getExistingComparison(repositoryRoot);
+        if (comparison?.isLoaded) {
+            await this.refreshComparison(comparison, true);
+            return;
+        }
+        // The initial load already computes refs and the complete diff. Do not
+        // immediately run a second refresh when Refresh races tree expansion.
+        if (await this.loadComparison(repositoryRoot)) {
+            this.fireTreeDataChange();
+        }
     }
 
     async manualRefreshAll() {
-        const repositoryRoots = this.multiRepositoryView ? this.getCurrentRepositoryRoots(true) : [];
-        if (repositoryRoots.length > 1) {
-            window.withProgress({ location: ProgressLocation.Window, title: 'Updating Tree' }, async _ => {
-                for (const repoRoot of repositoryRoots) {
-                    if (!await this.hydrateRepository(repoRoot)) {
-                        continue;
-                    }
-                    await this.refreshActiveRepository();
-                }
-                this.fireTreeDataChange();
-            });
+        if (!this.showRepositoryNodes()) {
+            await this.manualRefresh(undefined);
             return;
         }
-        if (!await this.ensureRepositoryForCommand(undefined)) {
-            window.showErrorMessage('No repository selected');
-            return;
-        }
-        window.withProgress({ location: ProgressLocation.Window, title: 'Updating Tree' }, async _ => {
-            await this.refreshActiveRepository();
-        });
-    }
-
-    private async refreshActiveRepository() {
-        try {
-            if (await this.isHeadChanged()) {
-                // make sure merge base is updated when switching branches
-                await this.updateRefs(this.baseRef);
+        await window.withProgress({ location: ProgressLocation.Window, title: 'Updating Tree' }, async _ => {
+            for (const repoRoot of this.getRepositoryRoots(true)) {
+                await this.refreshOrLoadComparison(repoRoot);
             }
-            await this.updateDiff(true);
-            this.saveRepositoryState();
-        } catch (e: any) {
-            let msg = 'Updating the git tree failed';
-            this.log(msg, e);
-            window.showErrorMessage(`${msg}: ${e.message}`);
-        }
+            this.fireTreeDataChange();
+        });
     }
 
     async switchToMergeDiff() {
@@ -2147,95 +2312,116 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
         this.fireTreeDataChange();
     }
 
+    /**
+     * Builds a workspace search include pattern for a file.
+     *
+     * Patterns have to use forward slashes, and have to be anchored with `./`
+     * and qualified with the workspace folder in multi-root workspaces.
+     * A bare relative path would otherwise also match the same path inside
+     * every other workspace folder.
+     */
+    private toSearchPattern(absPath: string): string | undefined {
+        const folder = workspace.getWorkspaceFolder(Uri.file(absPath));
+        if (!folder) {
+            return undefined;
+        }
+        const relPath = path.relative(folder.uri.fsPath, absPath).split(path.sep).join('/');
+        if (!relPath || relPath.startsWith('../')) {
+            return undefined;
+        }
+        const multiRoot = (workspace.workspaceFolders?.length ?? 0) > 1;
+        // In multi-root workspaces the first segment is matched against the
+        // workspace folder name, which can be overridden in a .code-workspace
+        // file and is therefore not always the directory basename.
+        return multiRoot ? `./${folder.name}/${relPath}` : `./${relPath}`;
+    }
+
     async searchChanges(entry?: RefElement | RepositoryElement) {
-        if (!await this.ensureRepositoryForCommand(entry)) {
+        const comparison = await this.resolveComparison(entry);
+        if (!comparison) {
             return;
         }
-        const relativePaths = [...this.iterFiles()]
-            .map(file => path.relative(this.workspaceFolder, file.dstAbsPath))
-            .filter(relPath => relPath && !relPath.startsWith('..' + path.sep) && relPath !== '..');
-        if (relativePaths.length === 0) {
-            window.showInformationMessage('No changed files to search.');
+        const files = [...comparison.iterFiles()];
+        const patterns: string[] = [];
+        for (const file of files) {
+            const pattern = this.toSearchPattern(file.dstAbsPath);
+            if (pattern) {
+                patterns.push(pattern);
+            }
+        }
+        if (patterns.length === 0) {
+            window.showInformationMessage(files.length === 0
+                ? 'No changed files to search.'
+                : 'No changed files inside the workspace to search.');
             return;
+        }
+        if (patterns.length < files.length) {
+            this.log(`Excluding ${files.length - patterns.length} changed file(s) outside the workspace from search`);
         }
         await commands.executeCommand('workbench.action.findInFiles', {
             query: '',
-            filesToInclude: relativePaths.join(','),
+            filesToInclude: patterns.join(','),
             triggerSearch: true
         });
     }
 
     async filterFiles(entry?: RefElement | RepositoryElement) {
-        if (!await this.ensureRepositoryForCommand(entry)) {
+        const comparison = await this.resolveComparison(entry);
+        if (!comparison) {
             return;
         }
         const searchTerm = await window.showInputBox({
             prompt: 'Enter text to filter files (leave empty to show all)',
             placeHolder: 'Filter by filename or path...',
-            value: this.searchFilter || ''
+            value: comparison.searchFilter || ''
         });
 
         if (searchTerm === undefined) {
             return;
         }
 
-        this.searchFilter = searchTerm.trim() || undefined;
-        this.saveRepositoryState();
-        this.updateTreeTitleForCurrentRepository();
-        this.updateFilterContext();
-        this.log(this.searchFilter ? `Filtering files by: ${this.searchFilter}` : 'Cleared file filter');
+        comparison.searchFilter = searchTerm.trim() || undefined;
+        this.updateViewState();
+        this.log(comparison.searchFilter ? `Filtering files by: ${comparison.searchFilter}` : 'Cleared file filter');
         this.fireTreeDataChange();
     }
 
     async clearFilter(entry?: RefElement | RepositoryElement) {
-        if (!await this.ensureRepositoryForCommand(entry)) {
+        const comparison = await this.resolveComparison(entry);
+        if (!comparison || !comparison.searchFilter) {
             return;
         }
-        if (!this.searchFilter) {
-            return;
-        }
-        this.searchFilter = undefined;
-        this.saveRepositoryState();
-        this.updateTreeTitleForCurrentRepository();
-        this.updateFilterContext();
+        comparison.searchFilter = undefined;
+        this.updateViewState();
         this.log('Cleared file filter');
         this.fireTreeDataChange();
     }
 
-    private updateFilterContext() {
-        const isFiltered = !!this.searchFilter || [...this.repositoryStates.values()].some(state => state.searchFilter);
-        commands.executeCommand('setContext', NAMESPACE + '.isFiltered', isFiltered);
-    }
-
     async copyPath(fileEntry: FileElement) {
-        const diffStatus = this.getDiffStatus(fileEntry);
-        if (!diffStatus) {
+        const resolved = this.resolveFile(fileEntry);
+        if (!resolved) {
             return;
         }
-        await env.clipboard.writeText(diffStatus.dstAbsPath);
+        await env.clipboard.writeText(resolved.status.dstAbsPath);
     }
 
     async copyRelativePath(fileEntry: FileElement) {
-        const diffStatus = this.getDiffStatus(fileEntry);
-        if (!diffStatus) {
+        const resolved = this.resolveFile(fileEntry);
+        if (!resolved) {
             return;
         }
         // Calculate relative path from workspace folder root (not git repo root)
         // Note: If the file is outside the workspace folder, the path will start with ../
-        const relativePath = path.relative(this.workspaceFolder, diffStatus.dstAbsPath);
+        const relativePath = path.relative(resolved.comparison.workspaceFolder, resolved.status.dstAbsPath);
         await env.clipboard.writeText(relativePath);
     }
 
     async openChangesWithDifftool(fileEntry: FileElement) {
-        const diffStatus = this.getDiffStatus(fileEntry);
-        if (!diffStatus) {
+        const resolved = this.resolveFile(fileEntry);
+        if (!resolved) {
             return;
         }
-
-        if (!this.repository) {
-            window.showErrorMessage('No repository is active.');
-            return;
-        }
+        const { comparison, status: diffStatus } = resolved;
 
         const { dstAbsPath, status } = diffStatus;
 
@@ -2252,15 +2438,15 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
         }
 
         // Calculate relative path from repository root
-        const dstRelPath = path.relative(this.repository.root, dstAbsPath);
+        const dstRelPath = path.relative(comparison.repository.root, dstAbsPath);
 
         // For modified files, use git difftool
         // Use the mergeBase as the comparison base
-        const args = ['difftool', '--no-prompt', this.mergeBase, '--', dstRelPath];
+        const args = ['difftool', '--no-prompt', comparison.mergeBase, '--', dstRelPath];
 
         try {
             // Execute git difftool - this will launch the external tool
-            await this.repository.exec(args);
+            await comparison.repository.exec(args);
         } catch (error: any) {
             const errorMessage = error.stderr || error.message || 'Unknown error';
             // Check for common error patterns indicating difftool is not configured
@@ -2277,7 +2463,13 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
     }
 
     dispose(): void {
-        this.extraRepositoryWatcher?.dispose();
+        this.disposed = true;
+        this.invalidateComparisonCreations();
+        this.disposeExtraRepositoryWatchers();
+        for (const subscription of this.repositoryUiSubscriptions.values()) {
+            subscription.dispose();
+        }
+        this.repositoryUiSubscriptions.clear();
         this.disposables.forEach(d => d.dispose());
     }
 }
@@ -2379,8 +2571,11 @@ function toTreeItem(element: Element, openChangesOnSelect: boolean, iconsMinimal
         }
         return item;
     } else if (element instanceof RepositoryElement) {
-        const state = element.hasChildren ? TreeItemCollapsibleState.Collapsed : TreeItemCollapsibleState.None;
+        // Repository sections stay expanded. The collapsed setting applies to
+        // folders inside each repository, not to the repository itself.
+        const state = element.hasChildren ? TreeItemCollapsibleState.Expanded : TreeItemCollapsibleState.None;
         const item = new TreeItem(element.label, state);
+        item.description = element.description;
         item.tooltip = element.repositoryRoot;
         item.contextValue = 'repo';
         item.id = getElementId(element);


### PR DESCRIPTION
## Summary

I love this extension and use it more than VS Code's built-in Git view for reviewing changes. One thing I kept wanting for my workflow was the ability to see changes across multiple repositories in the same workspace without switching the active repository manually. I often have several repos with 1-2 files changed in them.

This PR adds an experimental `gitTreeCompare.multiRepositoryView` setting. When enabled, Git Tree Compare shows one expandable section per open Git repository. The default behavior is unchanged.

## Screenshot

<img width="391" height="739" alt="image" src="https://github.com/user-attachments/assets/85508286-5afc-490a-a57b-0018206471be" />

## What Changed

- Added `gitTreeCompare.multiRepositoryView` feature flag to settings.
- When multiple repositories are open and the flag is enabled, the tree renders top-level repository nodes.
- Repository-level context actions operate on the selected repository.
- Single-repository workspaces keep the original behavior, even if the flag is enabled.
- Per-repository state is tracked for base refs, diff results, checkbox state, and filters.
- Auto-refresh now batches file-system changes per repository so a burst of changes across repos does not drop refreshes for earlier repos.

## Why

I work in multi-root workspaces where related changes often span several repos. The current extension can compare one repository at a time, but switching back and forth makes review prep harder than it needs to be.

This keeps the existing single-repo flow intact while making the multi-repo workflow available behind a flag.

My intent is to use my own fork regardless. I am also going to have a private build that integrates with some internal tooling from my company, but I wanted to offer the agnostic parts back here in case they are useful to others and would happily make that an upstream.

I kept this scoped to the generic multi-repository behavior.

That said, `treeProvider.ts` is doing a lot already, and this change adds more state management to it. It may be that this should land differently, or that `treeProvider` should be refactored first before taking on multi-repository state. If there are gotchas in the extension architecture, UX concerns, or a preferred direction for how to structure this, I am happy to adjust.

## Manual Testing

- Verified the existing single-repository behavior still works with the setting disabled.
- Verified a single repository still behaves like the original view when the setting is enabled.
- Verified multiple repositories render as separate top-level sections when the setting is enabled.
- Verified repo-level refresh only refreshes that repository.
- Verified title-bar refresh refreshes all repositories in multi-repo mode.
- Verified auto-refresh handles changes in multiple repositories within the debounce window.
- Verified removed workspace repositories disappear from the tree.