### PR TITLE
Add per-file diff stats (insertions/deletions) to tree view

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,3 +81,5 @@ This feature works with both PRs from the same repository and PRs from forks.
 `gitTreeCompare.refSortOrder` Determines how refs (branches, tags) are sorted when changing the comparison base. Default is `committerdate` which sorts by most recently committed first, making it easy to find recently-used branches. Can be set to `alphabetically` for alphabetical sorting.
 
 `gitTreeCompare.openChangesWithDifftool` When enabled, adds an "Open Changes with Difftool" command to the context menu for files. This command opens the changes in the external diff tool configured in Git (e.g., via `git config diff.tool <tool-name>`). Default is disabled. Note: This requires you to have a difftool configured in your Git settings.
+
+`gitTreeCompare.showDiffStats` When enabled, shows insertion/deletion counts (+N -N) next to each file name in the tree view. Default is enabled.

--- a/README.md
+++ b/README.md
@@ -82,4 +82,4 @@ This feature works with both PRs from the same repository and PRs from forks.
 
 `gitTreeCompare.openChangesWithDifftool` When enabled, adds an "Open Changes with Difftool" command to the context menu for files. This command opens the changes in the external diff tool configured in Git (e.g., via `git config diff.tool <tool-name>`). Default is disabled. Note: This requires you to have a difftool configured in your Git settings.
 
-`gitTreeCompare.showDiffStats` When enabled, shows insertion/deletion counts (+N -N) next to each file name in the tree view. Default is enabled.
+`gitTreeCompare.showDiffStats` When enabled, shows insertion/deletion counts (+N -N) next to each file name in the tree view. Default is disabled.

--- a/package.json
+++ b/package.json
@@ -597,6 +597,11 @@
                     "type": "boolean",
                     "description": "Whether to show the 'Open Changes with Difftool' command in the context menu for files. This command opens the changes in the external diff tool configured in Git (e.g., via 'git config diff.tool').",
                     "default": false
+                },
+                "gitTreeCompare.showDiffStats": {
+                    "type": "boolean",
+                    "description": "Whether to show insertion/deletion counts (+N -N) next to each file.",
+                    "default": true
                 }
             }
         }

--- a/package.json
+++ b/package.json
@@ -601,7 +601,7 @@
                 "gitTreeCompare.showDiffStats": {
                     "type": "boolean",
                     "description": "Whether to show insertion/deletion counts (+N -N) next to each file.",
-                    "default": true
+                    "default": false
                 }
             }
         }

--- a/src/gitHelper.ts
+++ b/src/gitHelper.ts
@@ -176,7 +176,6 @@ const SHA1_LEN = 40;
 const SRC_MODE_OFFSET = 1;
 const DST_MODE_OFFSET = 2 + MODE_LEN;
 const STATUS_OFFSET = 2 * MODE_LEN + 2 * SHA1_LEN + 5;
-const BINARY_CHECK_BYTES = 8192;
 
 function parseDiffIndexOutput(repoRoot: string, out: string): IDiffStatus[] {
     const entries: IDiffStatus[] = [];
@@ -225,6 +224,8 @@ function parseDiffNumstat(repoRoot: string, out: string): Map<string, IDiffStats
     return stats;
 }
 
+const BINARY_CHECK_BYTES = 8192;
+
 async function computeUntrackedStats(entries: IDiffStatus[]): Promise<void> {
     await Promise.all(entries.map(async (entry) => {
         try {
@@ -268,22 +269,11 @@ export async function diffIndex(repo: Repository, ref: string, refreshIndex: boo
         diffIndexArgs.push('--cached');
     }
     diffIndexArgs.push(ref, '--');
-    const diffIndexPromise = repo.exec(diffIndexArgs);
-
-    const untrackedPromise = omitUntrackedFiles
-        ? undefined
-        : repo.exec(['ls-files', '-z', '--others', '--exclude-standard']);
-
-    const numstatPromise = showDiffStats
-        ? repo.exec(['diff', '--numstat', renamesFlag, ref, '--'])
-        : undefined;
-
-    const [diffIndexResult, untrackedResult, numstatResult] = await Promise.all([
-        diffIndexPromise, untrackedPromise, numstatPromise
-    ]);
-
+    let diffIndexResult = await repo.exec(diffIndexArgs);
+    
     let untrackedStatuses: IDiffStatus[] = [];
-    if (untrackedResult) {
+    if (!omitUntrackedFiles) {
+        let untrackedResult = await repo.exec(['ls-files', '-z', '--others', '--exclude-standard']);
         untrackedStatuses = untrackedResult.stdout.split('\0')
             .slice(0, -1)
             .map(line => new DiffStatus(repoRoot, 'U' as 'U', line, undefined, MODE_EMPTY, MODE_REGULAR_FILE));
@@ -300,7 +290,8 @@ export async function diffIndex(repo: Repository, ref: string, refreshIndex: boo
 
     const statuses = filteredDiffIndexStatuses.concat(untrackedStatuses);
 
-    if (numstatResult) {
+    if (showDiffStats) {
+        const numstatResult = await repo.exec(['diff', '--numstat', renamesFlag, ref, '--']);
         const numstatMap = parseDiffNumstat(repoRoot, numstatResult.stdout);
         for (const entry of statuses) {
             const fileStats = numstatMap.get(entry.dstAbsPath) || numstatMap.get(entry.srcAbsPath);
@@ -308,10 +299,10 @@ export async function diffIndex(repo: Repository, ref: string, refreshIndex: boo
                 entry.stats = fileStats;
             }
         }
-    }
 
-    if (showDiffStats && untrackedStatuses.length > 0) {
-        await computeUntrackedStats(untrackedStatuses);
+        if (untrackedStatuses.length > 0) {
+            await computeUntrackedStats(untrackedStatuses);
+        }
     }
 
     statuses.sort((s1, s2) => s1.dstAbsPath.localeCompare(s2.dstAbsPath))

--- a/src/gitHelper.ts
+++ b/src/gitHelper.ts
@@ -176,6 +176,7 @@ const SHA1_LEN = 40;
 const SRC_MODE_OFFSET = 1;
 const DST_MODE_OFFSET = 2 + MODE_LEN;
 const STATUS_OFFSET = 2 * MODE_LEN + 2 * SHA1_LEN + 5;
+const BINARY_CHECK_BYTES = 8192;
 
 function parseDiffIndexOutput(repoRoot: string, out: string): IDiffStatus[] {
     const entries: IDiffStatus[] = [];
@@ -227,10 +228,10 @@ function parseDiffNumstat(repoRoot: string, out: string): Map<string, IDiffStats
 async function computeUntrackedStats(entries: IDiffStatus[]): Promise<void> {
     await Promise.all(entries.map(async (entry) => {
         try {
-            const buf = Buffer.alloc(8192);
+            const buf = Buffer.alloc(BINARY_CHECK_BYTES);
             const handle = await fs.open(entry.dstAbsPath, 'r');
             try {
-                const { bytesRead } = await handle.read(buf, 0, 8192, 0);
+                const { bytesRead } = await handle.read(buf, 0, BINARY_CHECK_BYTES, 0);
                 if (buf.subarray(0, bytesRead).includes(0)) {
                     entry.stats = { insertions: undefined, deletions: undefined, isBinary: true };
                     return;

--- a/src/gitHelper.ts
+++ b/src/gitHelper.ts
@@ -224,6 +224,30 @@ function parseDiffNumstat(repoRoot: string, out: string): Map<string, IDiffStats
     return stats;
 }
 
+async function computeUntrackedStats(entries: IDiffStatus[]): Promise<void> {
+    await Promise.all(entries.map(async (entry) => {
+        try {
+            const buf = Buffer.alloc(8192);
+            const handle = await fs.open(entry.dstAbsPath, 'r');
+            try {
+                const { bytesRead } = await handle.read(buf, 0, 8192, 0);
+                if (buf.subarray(0, bytesRead).includes(0)) {
+                    entry.stats = { insertions: undefined, deletions: undefined, isBinary: true };
+                    return;
+                }
+            } finally {
+                await handle.close();
+            }
+            const content = await fs.readFile(entry.dstAbsPath, 'utf-8');
+            const lines = content.split('\n');
+            const lineCount = content.endsWith('\n') ? lines.length - 1 : lines.length;
+            entry.stats = { insertions: lineCount, deletions: 0, isBinary: false };
+        } catch {
+            // File may be inaccessible
+        }
+    }));
+}
+
 export async function diffIndex(repo: Repository, ref: string, refreshIndex: boolean, findRenames: boolean, renameThreshold: number, omitUntrackedFiles: boolean, omitUnstagedChanges: boolean, showDiffStats: boolean = false): Promise<IDiffStatus[]> {
     if (refreshIndex) {
         // avoid superfluous diff entries if files only got touched
@@ -283,6 +307,10 @@ export async function diffIndex(repo: Repository, ref: string, refreshIndex: boo
                 entry.stats = fileStats;
             }
         }
+    }
+
+    if (showDiffStats && untrackedStatuses.length > 0) {
+        await computeUntrackedStats(untrackedStatuses);
     }
 
     statuses.sort((s1, s2) => s1.dstAbsPath.localeCompare(s2.dstAbsPath))

--- a/src/gitHelper.ts
+++ b/src/gitHelper.ts
@@ -110,6 +110,12 @@ export async function getHeadModificationDate(absGitDir: string): Promise<Date> 
     return stats.mtime;
 }
 
+export interface IDiffStats {
+    insertions: number | undefined;
+    deletions: number | undefined;
+    isBinary: boolean;
+}
+
 export interface IDiffStatus {
     /**
      * A Addition of a file
@@ -130,6 +136,9 @@ export interface IDiffStatus {
 
     /** True if this was or is a submodule */
     isSubmodule: boolean
+
+    /** Per-file insertion/deletion counts (undefined when stats are disabled or unavailable) */
+    stats: IDiffStats | undefined;
 }
 
 const MODE_REGULAR_FILE = '100644';
@@ -140,6 +149,7 @@ class DiffStatus implements IDiffStatus {
     readonly srcAbsPath: string;
     readonly dstAbsPath: string;
     readonly isSubmodule: boolean;
+    stats: IDiffStats | undefined;
 
     constructor(repoRoot: string, public status: StatusCode, srcRelPath: string, dstRelPath: string | undefined, srcMode: string, dstMode: string) {
         this.srcAbsPath = path.join(repoRoot, srcRelPath);
@@ -194,7 +204,27 @@ function parseDiffIndexOutput(repoRoot: string, out: string): IDiffStatus[] {
     return entries;
 }
 
-export async function diffIndex(repo: Repository, ref: string, refreshIndex: boolean, findRenames: boolean, renameThreshold: number, omitUntrackedFiles: boolean, omitUnstagedChanges: boolean): Promise<IDiffStatus[]> {
+function parseDiffNumstat(repoRoot: string, out: string): Map<string, IDiffStats> {
+    const stats = new Map<string, IDiffStats>();
+    const lines = out.split('\n').filter(line => line.length > 0);
+    for (const line of lines) {
+        const parts = line.split('\t');
+        if (parts.length < 3) {
+            continue;
+        }
+        const [ins, del, ...pathParts] = parts;
+        const relPath = pathParts.join('\t');
+        const absPath = path.join(repoRoot, relPath);
+        if (ins === '-' && del === '-') {
+            stats.set(absPath, { insertions: undefined, deletions: undefined, isBinary: true });
+        } else {
+            stats.set(absPath, { insertions: parseInt(ins, 10), deletions: parseInt(del, 10), isBinary: false });
+        }
+    }
+    return stats;
+}
+
+export async function diffIndex(repo: Repository, ref: string, refreshIndex: boolean, findRenames: boolean, renameThreshold: number, omitUntrackedFiles: boolean, omitUnstagedChanges: boolean, showDiffStats: boolean = false): Promise<IDiffStatus[]> {
     if (refreshIndex) {
         // avoid superfluous diff entries if files only got touched
         // (see https://github.com/letmaik/vscode-git-tree-compare/issues/37)
@@ -213,11 +243,22 @@ export async function diffIndex(repo: Repository, ref: string, refreshIndex: boo
         diffIndexArgs.push('--cached');
     }
     diffIndexArgs.push(ref, '--');
-    let diffIndexResult = await repo.exec(diffIndexArgs);
-    
+    const diffIndexPromise = repo.exec(diffIndexArgs);
+
+    const untrackedPromise = omitUntrackedFiles
+        ? undefined
+        : repo.exec(['ls-files', '-z', '--others', '--exclude-standard']);
+
+    const numstatPromise = showDiffStats
+        ? repo.exec(['diff', '--numstat', renamesFlag, ref, '--'])
+        : undefined;
+
+    const [diffIndexResult, untrackedResult, numstatResult] = await Promise.all([
+        diffIndexPromise, untrackedPromise, numstatPromise
+    ]);
+
     let untrackedStatuses: IDiffStatus[] = [];
-    if (!omitUntrackedFiles) {
-        let untrackedResult = await repo.exec(['ls-files', '-z', '--others', '--exclude-standard']);
+    if (untrackedResult) {
         untrackedStatuses = untrackedResult.stdout.split('\0')
             .slice(0, -1)
             .map(line => new DiffStatus(repoRoot, 'U' as 'U', line, undefined, MODE_EMPTY, MODE_REGULAR_FILE));
@@ -233,6 +274,17 @@ export async function diffIndex(repo: Repository, ref: string, refreshIndex: boo
     const filteredDiffIndexStatuses = diffIndexStatuses.filter(status => !untrackedAbsPaths.has(status.srcAbsPath));
 
     const statuses = filteredDiffIndexStatuses.concat(untrackedStatuses);
+
+    if (numstatResult) {
+        const numstatMap = parseDiffNumstat(repoRoot, numstatResult.stdout);
+        for (const entry of statuses) {
+            const fileStats = numstatMap.get(entry.dstAbsPath) || numstatMap.get(entry.srcAbsPath);
+            if (fileStats) {
+                entry.stats = fileStats;
+            }
+        }
+    }
+
     statuses.sort((s1, s2) => s1.dstAbsPath.localeCompare(s2.dstAbsPath))
     return statuses;
 }

--- a/src/treeProvider.ts
+++ b/src/treeProvider.ts
@@ -1810,11 +1810,10 @@ function toTreeItem(element: Element, openChangesOnSelect: boolean, iconsMinimal
             item.tooltip = `${item.tooltip} • ${statsText}`;
         }
         if (viewAsList) {
-            let desc = path.dirname(element.dstRelPath);
-            if (desc === '.') {
-                desc = '';
+            item.description = path.dirname(element.dstRelPath);
+            if (item.description === '.') {
+                item.description = '';
             }
-            item.description = desc;
         }
         item.contextValue = element.isSubmodule ? 'submodule' : 'file';
         item.id = element.dstAbsPath;

--- a/src/treeProvider.ts
+++ b/src/treeProvider.ts
@@ -800,7 +800,7 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
         // Always refresh when sorting by recently modified in list view, as file mtimes may have changed
         const needsRefreshForSorting = this.viewAsList && this.sortOrder === 'recentlyModified';
         
-        if (fireChangeEvents && (treeHasChanged || needsRefreshForSorting)) {
+        if (fireChangeEvents && (treeHasChanged || needsRefreshForSorting || this.showDiffStats)) {
             this.log('Refreshing tree')
             this.fireTreeDataChange();
         }

--- a/src/treeProvider.ts
+++ b/src/treeProvider.ts
@@ -423,7 +423,7 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
         this.omitUnstagedChanges = config.get<boolean>('omitUnstagedChanges', false);
         this.sortOrder = config.get<SortOrder>('sortOrder', 'path');
         this.autoReveal = config.get<boolean>('autoReveal', true);
-        this.showDiffStats = config.get<boolean>('showDiffStats', true);
+        this.showDiffStats = config.get<boolean>('showDiffStats', false);
     }
 
     private async getStoredBaseRef(): Promise<string | undefined> {

--- a/src/treeProvider.ts
+++ b/src/treeProvider.ts
@@ -11,7 +11,7 @@ import { Repository, Git } from './git/git'
 import { Ref, RefType } from './git/api/git'
 import { anyEvent, filterEvent, eventToPromise } from './git/util'
 import { getDefaultBranch, getHeadModificationDate, getBranchCommit,
-         diffIndex, IDiffStatus, StatusCode, getAbsGitDir,
+         diffIndex, IDiffStatus, IDiffStats, StatusCode, getAbsGitDir,
          getWorkspaceFolders, getGitRepositoryFolders, hasUncommittedChanges, rmFile } from './gitHelper'
 import { tryDeepenForMergeBase } from './deepenHelper'
 import { debounce, throttle } from './git/decorators'
@@ -47,7 +47,8 @@ class FileElement implements IDiffStatus {
         public dstAbsPath: string,
         public dstRelPath: string,
         public status: StatusCode,
-        public isSubmodule: boolean) {}
+        public isSubmodule: boolean,
+        public stats: IDiffStats | undefined = undefined) {}
 
     get label(): string {
         return path.basename(this.dstAbsPath)
@@ -139,6 +140,7 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
     private omitUnstagedChanges: boolean;
     private sortOrder: SortOrder;
     private autoReveal: boolean;
+    private showDiffStats: boolean;
 
     // Dynamic options
     private repository: Repository | undefined;
@@ -421,6 +423,7 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
         this.omitUnstagedChanges = config.get<boolean>('omitUnstagedChanges', false);
         this.sortOrder = config.get<SortOrder>('sortOrder', 'path');
         this.autoReveal = config.get<boolean>('autoReveal', true);
+        this.showDiffStats = config.get<boolean>('showDiffStats', true);
     }
 
     private async getStoredBaseRef(): Promise<string | undefined> {
@@ -466,7 +469,7 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
                 checkboxState = this.computeFolderCheckboxState(element);
             }
         }
-        return toTreeItem(element, this.openChangesOnSelect, this.iconsMinimal, this.showCollapsed, this.viewAsList, checkboxState, this.asAbsolutePath);
+        return toTreeItem(element, this.openChangesOnSelect, this.iconsMinimal, this.showCollapsed, this.viewAsList, this.showDiffStats, checkboxState, this.asAbsolutePath);
     }
 
     getParent(element: Element): Element | undefined {
@@ -653,7 +656,7 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
         const filesInsideTreeRoot = new Map<FolderAbsPath, IDiffStatus[]>();
         const filesOutsideTreeRoot = new Map<FolderAbsPath, IDiffStatus[]>();
 
-        const diff = await diffIndex(this.repository!, this.mergeBase, this.refreshIndex, this.findRenames, this.renameThreshold, this.omitUntrackedFiles, this.omitUnstagedChanges);
+        const diff = await diffIndex(this.repository!, this.mergeBase, this.refreshIndex, this.findRenames, this.renameThreshold, this.omitUntrackedFiles, this.omitUnstagedChanges, this.showDiffStats);
         const untrackedCount = diff.reduce((prev, cur, _) => prev + (cur.status === 'U' ? 1 : 0), 0);
         this.log(`${diff.length} diff entries (${untrackedCount} untracked)`);
 
@@ -884,6 +887,7 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
         const oldOmitUntrackedFiles = this.omitUntrackedFiles;
         const oldOmitUnstagedChanges = this.omitUnstagedChanges;
         const oldSortOrder = this.sortOrder;
+        const oldShowDiffStats = this.showDiffStats;
         this.readConfig();
         if (oldTreeRootIsRepo != this.treeRootIsRepo ||
             oldInclude != this.includeFilesOutsideWorkspaceFolderRoot ||
@@ -898,7 +902,8 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
             oldshowCheckboxes != this.showCheckboxes ||
             oldOmitUntrackedFiles != this.omitUntrackedFiles ||
             oldOmitUnstagedChanges != this.omitUnstagedChanges ||
-            oldSortOrder != this.sortOrder) {
+            oldSortOrder != this.sortOrder ||
+            oldShowDiffStats != this.showDiffStats) {
 
             if (!this.repository) {
                 return;
@@ -916,7 +921,8 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
                 (!oldAutoRefresh && this.autoRefresh) ||
                 (!oldRefreshIndex && this.refreshIndex) ||
                 oldOmitUntrackedFiles != this.omitUntrackedFiles ||
-                oldOmitUnstagedChanges != this.omitUnstagedChanges) {
+                oldOmitUnstagedChanges != this.omitUnstagedChanges ||
+                oldShowDiffStats != this.showDiffStats) {
                 try {
                     await this.updateRefs(this.baseRef);
                     await this.updateDiff(false);
@@ -983,7 +989,7 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
                 for (const file of fileEntries) {
                     if (this.matchesFilter(file.dstAbsPath, relPathBase)) {
                         const dstRelPath = path.relative(relPathBase, file.dstAbsPath);
-                        entries.push(new FileElement(file.srcAbsPath, file.dstAbsPath, dstRelPath, file.status, file.isSubmodule));
+                        entries.push(new FileElement(file.srcAbsPath, file.dstAbsPath, dstRelPath, file.status, file.isSubmodule, file.stats));
                     }
                 }
             }
@@ -1046,7 +1052,7 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
             for (const file of fileEntries) {
                 if (this.matchesFilter(file.dstAbsPath, relPathBase)) {
                     const dstRelPath = path.relative(relPathBase, file.dstAbsPath);
-                    entries.push(new FileElement(file.srcAbsPath, file.dstAbsPath, dstRelPath, file.status, file.isSubmodule));
+                    entries.push(new FileElement(file.srcAbsPath, file.dstAbsPath, dstRelPath, file.status, file.isSubmodule, file.stats));
                 }
             }
         }
@@ -1772,23 +1778,43 @@ function getElementId(element: Element): string {
     }
 }
 
+function formatDiffStats(stats: IDiffStats): string {
+    if (stats.isBinary) {
+        return 'binary';
+    }
+    const parts: string[] = [];
+    if (stats.insertions !== undefined && stats.insertions > 0) {
+        parts.push(`+${stats.insertions}`);
+    }
+    if (stats.deletions !== undefined && stats.deletions > 0) {
+        parts.push(`-${stats.deletions}`);
+    }
+    return parts.join(' ');
+}
+
 function toTreeItem(element: Element, openChangesOnSelect: boolean, iconsMinimal: boolean,
-                    showCollapsed: boolean, viewAsList: boolean,
+                    showCollapsed: boolean, viewAsList: boolean, showDiffStats: boolean,
                     checkboxState: TreeItemCheckboxState | undefined,
                     asAbsolutePath: (relPath: string) => string): TreeItem {
     const gitIconRoot = asAbsolutePath('resources/git-icons');
     if (element instanceof FileElement) {
-        const item = new TreeItem(element.label);
+        const statsText = showDiffStats && element.stats ? formatDiffStats(element.stats) : '';
+        const displayLabel = statsText ? `${element.label}  ${statsText}` : element.label;
+        const item = new TreeItem(displayLabel);
         const statusText = getStatusText(element);
         item.tooltip = `${element.dstAbsPath} • ${statusText}`;
         if (element.srcAbsPath !== element.dstAbsPath) {
             item.tooltip = `${element.srcAbsPath} → ${item.tooltip}`;
         }
+        if (statsText) {
+            item.tooltip = `${item.tooltip} • ${statsText}`;
+        }
         if (viewAsList) {
-            item.description = path.dirname(element.dstRelPath);
-            if (item.description === '.') {
-                item.description = '';
+            let desc = path.dirname(element.dstRelPath);
+            if (desc === '.') {
+                desc = '';
             }
+            item.description = desc;
         }
         item.contextValue = element.isSubmodule ? 'submodule' : 'file';
         item.id = element.dstAbsPath;


### PR DESCRIPTION
First off, thank you @letmaik for building and maintaining this extension. It has become one of my most used tools in VS Code and it's become an essential part of my workflow.

This PR adds an opt-in feature that displays per-file insertion and deletion counts (+N -N) next to each filename in the tree view, giving a quick sense of change magnitude without having to open individual diffs. This is personally something I use a lot during my work day. Being able to glance at which files have the heaviest changes without clicking into each one saves me a surprising amount of time. I've had this running in my custom build for a while now and recently decided to clean it up and share it with the community.

### **What it does**
- Runs git diff --numstat to gather per-file insertion/deletion counts for tracked files
- Computes stats for untracked files by reading them directly (line count for text files, binary label for binary files)
- Displays the stats after the filename in the tree item label (e.g. myFile.ts +42 -7)
- Stats update live as files are edited (respects the existing 2-second debounce)
- Fully toggleable via gitTreeCompare.showDiffStats setting (disabled by default)

### **Changes**
- src/gitHelper.ts -> Added IDiffStats interface, parseDiffNumstat() parser, computeUntrackedStats() for untracked files, and a showDiffStats path in diffIndex().
- src/treeProvider.ts -> Reads the new config, passes stats through to FileElement, and formats them in toTreeItem() via a formatDiffStats() helper.
- package.json -> Added gitTreeCompare.showDiffStats boolean config.

Ideally, insertions would be green and deletions red, but the VS Code TreeItem API does not support inline color formatting within labels or descriptions, so the stats are displayed as just plain text.

<img width="281" height="179" alt="image" src="https://github.com/user-attachments/assets/7c05b8f4-c72c-4fa8-a4e9-49e92bd4e4b4" />

<img width="511" height="119" alt="image" src="https://github.com/user-attachments/assets/0a71f9fe-6ab2-4c69-ba1f-faf3251a28a1" />


