### PR TITLE
Add commits panel to filter the comparison by commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 1.20.0
 
+* Add a commits panel to filter the comparison by individual commits
 * Add `autoReveal` option to automatically reveal and select the tree item corresponding to the active editor (enabled by default)
 * Add file filter functionality to tree view
 * Automatically offer to fetch more history when merge base cannot be found in shallow clones

--- a/package.json
+++ b/package.json
@@ -57,7 +57,15 @@
                     "id": "gitTreeCompare",
                     "name": "none",
                     "when": "config.git.enabled && gitOpenRepositoryCount != 0",
-                    "icon": "./resources/logo.svg"
+                    "icon": "./resources/logo.svg",
+                    "initialSize": 3
+                },
+                {
+                    "id": "gitTreeCompareCommits",
+                    "name": "Commits",
+                    "when": "config.git.enabled && gitOpenRepositoryCount != 0",
+                    "icon": "./resources/logo.svg",
+                    "initialSize": 1
                 }
             ]
         },
@@ -222,6 +230,24 @@
                 "command": "gitTreeCompare.openChangesWithDifftool",
                 "title": "Open Changes with Difftool",
                 "category": "Git Tree Compare"
+            },
+            {
+                "command": "gitTreeCompare.commits.selectAll",
+                "title": "Select All Commits",
+                "icon": "$(check-all)",
+                "category": "Git Tree Compare"
+            },
+            {
+                "command": "gitTreeCompare.commits.deselectAll",
+                "title": "Deselect All Commits",
+                "icon": "$(close-all)",
+                "category": "Git Tree Compare"
+            },
+            {
+                "command": "gitTreeCompare.commits.refresh",
+                "title": "Refresh Commits",
+                "icon": "$(refresh)",
+                "category": "Git Tree Compare"
             }
         ],
         "submenus": [
@@ -366,6 +392,21 @@
                     "submenu": "gitTreeCompare.viewAndSort",
                     "when": "view == gitTreeCompare",
                     "group": "0_view_and_sort"
+                },
+                {
+                    "command": "gitTreeCompare.commits.selectAll",
+                    "when": "view == gitTreeCompareCommits",
+                    "group": "navigation@1"
+                },
+                {
+                    "command": "gitTreeCompare.commits.deselectAll",
+                    "when": "view == gitTreeCompareCommits",
+                    "group": "navigation@2"
+                },
+                {
+                    "command": "gitTreeCompare.commits.refresh",
+                    "when": "view == gitTreeCompareCommits",
+                    "group": "navigation@3"
                 }
             ],
             "view/item/context": [

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
                 {
                     "id": "gitTreeCompareCommits",
                     "name": "Commits",
-                    "when": "config.git.enabled && gitOpenRepositoryCount != 0",
+                    "when": "config.git.enabled && gitOpenRepositoryCount != 0 && config.gitTreeCompare.showCommitsPanel",
                     "icon": "./resources/logo.svg",
                     "initialSize": 1
                 }
@@ -257,6 +257,20 @@
             }
         ],
         "menus": {
+            "commandPalette": [
+                {
+                    "command": "gitTreeCompare.commits.selectAll",
+                    "when": "config.gitTreeCompare.showCommitsPanel"
+                },
+                {
+                    "command": "gitTreeCompare.commits.deselectAll",
+                    "when": "config.gitTreeCompare.showCommitsPanel"
+                },
+                {
+                    "command": "gitTreeCompare.commits.refresh",
+                    "when": "config.gitTreeCompare.showCommitsPanel"
+                }
+            ],
             "gitTreeCompare.viewAndSort": [
                 {
                     "command": "gitTreeCompare.viewAsList",
@@ -544,6 +558,11 @@
                 "gitTreeCompare.autoChangeRepository": {
                     "type": "boolean",
                     "description": "[EXPERIMENTAL] Whether to change the active repository whenever a different one is selected in the SCM view. Note that this only works well when not selecting multiple repositories. See GitHub issue #70 for more details.",
+                    "default": false
+                },
+                "gitTreeCompare.showCommitsPanel": {
+                    "type": "boolean",
+                    "description": "Whether to show the \"Commits\" panel below the tree, which lists the commits between the base and HEAD and lets you filter the comparison to a subset of commits.",
                     "default": false
                 },
                 "gitTreeCompare.autoRefresh": {

--- a/src/commitsProvider.ts
+++ b/src/commitsProvider.ts
@@ -1,10 +1,11 @@
 import {
     TreeDataProvider, TreeItem, TreeItemCollapsibleState, EventEmitter, Event,
     Disposable, TreeItemCheckboxState, TreeCheckboxChangeEvent, TreeView, ThemeIcon,
-    OutputChannel, MarkdownString
+    OutputChannel, MarkdownString, window
 } from 'vscode';
 
 import { ICommitInfo, IUncommittedSummary, EMPTY_TREE_ID } from './gitHelper';
+import { debounce } from './git/decorators';
 
 /**
  * Describes which diff the main tree should display, derived from the set of
@@ -39,7 +40,14 @@ export interface ComparisonInfo {
  */
 export interface ComparisonHost {
     readonly onDidChangeComparison: Event<void>;
+    // Fired when a relevant working-tree/refs change is detected, independent of whether
+    // the main tree is currently visible. Used to auto-refresh the commits list.
+    readonly onDidChangeRepository: Event<void>;
     getComparison(): ComparisonInfo | undefined;
+    // Updates the cached comparison refs (merge base / HEAD) from git without recomputing
+    // the full file diff. Must be called before reading getComparison() on auto-refresh so
+    // the commits list picks up new commits even while the main tree is hidden.
+    refreshComparison(): Promise<void>;
     getBranchCommits(): Promise<ICommitInfo[]>;
     getUncommittedSummary(): Promise<IUncommittedSummary>;
     setCommitFilter(spec: CommitFilterSpec): Promise<void>;
@@ -86,17 +94,47 @@ export class CommitsTreeProvider implements TreeDataProvider<CommitListElement>,
     // Identifies the current comparison; used to detect when the commit set changed.
     private commitSetKey = '';
 
+    // The view backing this provider; used to gate auto-refresh on visibility.
+    private treeView: TreeView<CommitListElement> | undefined;
+
     private readonly disposables: Disposable[] = [];
 
     constructor(private readonly host: ComparisonHost, private readonly outputChannel: OutputChannel) {
         this.disposables.push(this.host.onDidChangeComparison(() => {
             this.refresh().catch(e => this.log('Failed to refresh commits list', e));
         }));
+        this.disposables.push(this.host.onDidChangeRepository(() => this.scheduleAutoRefresh()));
     }
 
     init(treeView: TreeView<CommitListElement>) {
+        this.treeView = treeView;
         this.disposables.push(treeView.onDidChangeCheckboxState(this.handleCheckboxChange, this));
+        // Refresh when the view becomes visible again to catch up on changes that
+        // happened while it was hidden.
+        this.disposables.push(treeView.onDidChangeVisibility(e => {
+            if (e.visible) {
+                this.autoRefresh().catch(err => this.log('Failed to refresh commits list on show', err));
+            }
+        }));
         this.refresh().catch(e => this.log('Failed to initialise commits list', e));
+    }
+
+    // Debounced auto-refresh triggered by repository changes. Skips work when the
+    // window is unfocused or the view is hidden; the visibility handler refreshes
+    // once the view is shown again.
+    @debounce(2000)
+    private scheduleAutoRefresh() {
+        this.autoRefresh().catch(e => this.log('Failed to auto-refresh commits list', e));
+    }
+
+    // Brings the comparison refs up to date (so new commits are picked up) and then
+    // refreshes the list, but only while the window is focused and the view is visible.
+    private async autoRefresh(): Promise<void> {
+        if (!window.state.focused || !(this.treeView?.visible ?? false)) {
+            return;
+        }
+        await this.host.refreshComparison();
+        await this.refresh();
     }
 
     private log(msg: string, error?: unknown) {
@@ -141,6 +179,32 @@ export class CommitsTreeProvider implements TreeDataProvider<CommitListElement>,
         }
     }
 
+    // The list is a single vertical timeline: the "Uncommitted Changes" entry sits
+    // on top (newest), followed by the commits newest-first. A selection always maps
+    // to a contiguous range of this timeline, so the ids are ordered accordingly.
+    private orderedIds(): string[] {
+        return [UNCOMMITTED_ID, ...this.commits.map(c => c.hash)];
+    }
+
+    // Snaps the current selection to a contiguous block: everything between the
+    // topmost and bottommost checked entry becomes checked, everything outside
+    // becomes unchecked. This keeps the checkboxes honest about the range that is
+    // actually diffed (intermediate commits can't be left out of a range).
+    private enforceContiguousSelection(): void {
+        const ids = this.orderedIds();
+        const checkedIndices = ids
+            .map((id, i) => (this.isChecked(id) ? i : -1))
+            .filter(i => i >= 0);
+        if (checkedIndices.length === 0) {
+            return; // nothing checked -> empty selection, leave as-is
+        }
+        const min = checkedIndices[0];
+        const max = checkedIndices[checkedIndices.length - 1];
+        ids.forEach((id, i) => {
+            this.checked.set(id, i >= min && i <= max);
+        });
+    }
+
     private computeSpec(): CommitFilterSpec {
         const total = this.commits.length + 1; // + uncommitted item
         const checkedCommits = this.commits.filter(c => this.isChecked(c.hash));
@@ -173,6 +237,10 @@ export class CommitsTreeProvider implements TreeDataProvider<CommitListElement>,
         for (const [element, state] of e.items) {
             this.checked.set(elementId(element), state === TreeItemCheckboxState.Checked);
         }
+        // Fill any gap so the checkboxes always show one contiguous range, then
+        // refresh the list to reflect the auto-checked entries.
+        this.enforceContiguousSelection();
+        this._onDidChangeTreeData.fire();
         await this.applyFilter();
     }
 

--- a/src/commitsProvider.ts
+++ b/src/commitsProvider.ts
@@ -1,0 +1,249 @@
+import {
+    TreeDataProvider, TreeItem, TreeItemCollapsibleState, EventEmitter, Event,
+    Disposable, TreeItemCheckboxState, TreeCheckboxChangeEvent, TreeView, ThemeIcon,
+    OutputChannel, MarkdownString
+} from 'vscode';
+
+import { ICommitInfo, IUncommittedSummary, EMPTY_TREE_ID } from './gitHelper';
+
+/**
+ * Describes which diff the main tree should display, derived from the set of
+ * checked items in the commits list.
+ *  - 'all':   the full comparison (working tree vs base), i.e. the default behaviour.
+ *  - 'empty': nothing checked, show no files.
+ *  - 'range': a tree-vs-tree or tree-vs-worktree diff between `leftRef` and `rightRef`.
+ *             `rightRef === null` means the working tree (used when "Uncommitted Changes"
+ *             is part of the selection).
+ */
+export interface CommitFilterSpec {
+    kind: 'all' | 'empty' | 'range';
+    leftRef?: string;
+    rightRef?: string | null;
+}
+
+export function commitFilterSpecEquals(a: CommitFilterSpec, b: CommitFilterSpec): boolean {
+    return a.kind === b.kind &&
+        (a.leftRef ?? null) === (b.leftRef ?? null) &&
+        (a.rightRef ?? null) === (b.rightRef ?? null);
+}
+
+export interface ComparisonInfo {
+    repoRoot: string;
+    mergeBase: string;
+    headCommit: string;
+}
+
+/**
+ * The contract the commits list relies on. Implemented by the main tree provider,
+ * which owns the repository and the active comparison.
+ */
+export interface ComparisonHost {
+    readonly onDidChangeComparison: Event<void>;
+    getComparison(): ComparisonInfo | undefined;
+    getBranchCommits(): Promise<ICommitInfo[]>;
+    getUncommittedSummary(): Promise<IUncommittedSummary>;
+    setCommitFilter(spec: CommitFilterSpec): Promise<void>;
+}
+
+const UNCOMMITTED_ID = 'uncommitted';
+
+export class UncommittedElement {
+    constructor(public summary: IUncommittedSummary) {}
+}
+
+export class CommitElement {
+    constructor(public commit: ICommitInfo) {}
+}
+
+export type CommitListElement = UncommittedElement | CommitElement;
+
+function elementId(element: CommitListElement): string {
+    return element instanceof CommitElement ? element.commit.hash : UNCOMMITTED_ID;
+}
+
+function formatSummary(fileCount: number, insertions: number, deletions: number): string {
+    const parts: string[] = [`${fileCount} ${fileCount === 1 ? 'file' : 'files'}`];
+    if (insertions > 0) {
+        parts.push(`+${insertions}`);
+    }
+    if (deletions > 0) {
+        parts.push(`-${deletions}`);
+    }
+    return parts.join(' ');
+}
+
+export class CommitsTreeProvider implements TreeDataProvider<CommitListElement>, Disposable {
+
+    private _onDidChangeTreeData = new EventEmitter<CommitListElement | void>();
+    readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
+
+    private commits: ICommitInfo[] = [];
+    private uncommitted: IUncommittedSummary = { fileCount: 0, insertions: 0, deletions: 0 };
+
+    // id -> checked. Absent means checked (the default state).
+    private checked = new Map<string, boolean>();
+
+    // Identifies the current comparison; used to detect when the commit set changed.
+    private commitSetKey = '';
+
+    private readonly disposables: Disposable[] = [];
+
+    constructor(private readonly host: ComparisonHost, private readonly outputChannel: OutputChannel) {
+        this.disposables.push(this.host.onDidChangeComparison(() => {
+            this.refresh().catch(e => this.log('Failed to refresh commits list', e));
+        }));
+    }
+
+    init(treeView: TreeView<CommitListElement>) {
+        this.disposables.push(treeView.onDidChangeCheckboxState(this.handleCheckboxChange, this));
+        this.refresh().catch(e => this.log('Failed to initialise commits list', e));
+    }
+
+    private log(msg: string, error?: unknown) {
+        if (error) {
+            const message = error instanceof Error ? error.message : String(error);
+            msg = `${msg}: ${message}`;
+        }
+        this.outputChannel.appendLine(msg);
+    }
+
+    private isChecked(id: string): boolean {
+        return this.checked.get(id) ?? true;
+    }
+
+    async refresh(): Promise<void> {
+        const comparison = this.host.getComparison();
+        if (!comparison) {
+            this.commits = [];
+            this.uncommitted = { fileCount: 0, insertions: 0, deletions: 0 };
+            this.commitSetKey = '';
+            this._onDidChangeTreeData.fire();
+            return;
+        }
+
+        const key = `${comparison.mergeBase}..${comparison.headCommit}`;
+        const keyChanged = key !== this.commitSetKey;
+
+        if (keyChanged) {
+            this.commits = await this.host.getBranchCommits();
+            this.commitSetKey = key;
+            // A new comparison resets the selection to "all" (everything checked).
+            this.checked.clear();
+        }
+        this.uncommitted = await this.host.getUncommittedSummary();
+
+        this._onDidChangeTreeData.fire();
+
+        if (keyChanged) {
+            // Selection was reset; make sure the main tree shows the full comparison.
+            // (No-op if the filter is already 'all'.)
+            await this.host.setCommitFilter({ kind: 'all' });
+        }
+    }
+
+    private computeSpec(): CommitFilterSpec {
+        const total = this.commits.length + 1; // + uncommitted item
+        const checkedCommits = this.commits.filter(c => this.isChecked(c.hash));
+        const uncommittedChecked = this.isChecked(UNCOMMITTED_ID);
+        const checkedCount = checkedCommits.length + (uncommittedChecked ? 1 : 0);
+
+        if (checkedCount === total) {
+            return { kind: 'all' };
+        }
+        if (checkedCount === 0) {
+            return { kind: 'empty' };
+        }
+        if (checkedCommits.length === 0) {
+            // Only uncommitted changes: working tree vs HEAD.
+            return { kind: 'range', leftRef: 'HEAD', rightRef: null };
+        }
+        // commits are newest-first, so the first checked is the newest and the last is the oldest.
+        const newest = checkedCommits[0];
+        const oldest = checkedCommits[checkedCommits.length - 1];
+        const leftRef = oldest.parents.length > 0 ? oldest.parents[0] : EMPTY_TREE_ID;
+        const rightRef = uncommittedChecked ? null : newest.hash;
+        return { kind: 'range', leftRef, rightRef };
+    }
+
+    private applyFilter(): Promise<void> {
+        return this.host.setCommitFilter(this.computeSpec());
+    }
+
+    private async handleCheckboxChange(e: TreeCheckboxChangeEvent<CommitListElement>) {
+        for (const [element, state] of e.items) {
+            this.checked.set(elementId(element), state === TreeItemCheckboxState.Checked);
+        }
+        await this.applyFilter();
+    }
+
+    async selectAll(): Promise<void> {
+        this.checked.clear(); // absent => checked
+        this._onDidChangeTreeData.fire();
+        await this.applyFilter();
+    }
+
+    async deselectAll(): Promise<void> {
+        this.checked.clear();
+        for (const c of this.commits) {
+            this.checked.set(c.hash, false);
+        }
+        this.checked.set(UNCOMMITTED_ID, false);
+        this._onDidChangeTreeData.fire();
+        await this.applyFilter();
+    }
+
+    getTreeItem(element: CommitListElement): TreeItem {
+        if (element instanceof CommitElement) {
+            const c = element.commit;
+            const item = new TreeItem(c.subject || c.shortHash, TreeItemCollapsibleState.None);
+            item.id = c.hash;
+            item.description = `${c.shortHash}  ${formatSummary(c.fileCount, c.insertions, c.deletions)}`;
+            item.iconPath = new ThemeIcon('git-commit');
+            item.contextValue = 'commit';
+            item.checkboxState = this.isChecked(c.hash) ? TreeItemCheckboxState.Checked : TreeItemCheckboxState.Unchecked;
+            const tooltip = new MarkdownString();
+            tooltip.appendMarkdown(`**${escapeMarkdown(c.subject)}**\n\n`);
+            tooltip.appendMarkdown(`\`${c.shortHash}\``);
+            if (c.authorName) {
+                tooltip.appendMarkdown(` &middot; ${escapeMarkdown(c.authorName)}`);
+            }
+            if (c.authorDate) {
+                tooltip.appendMarkdown(` &middot; ${c.authorDate.toLocaleString()}`);
+            }
+            tooltip.appendMarkdown(`\n\n${formatSummary(c.fileCount, c.insertions, c.deletions)}`);
+            item.tooltip = tooltip;
+            return item;
+        }
+        const s = element.summary;
+        const item = new TreeItem('Uncommitted Changes', TreeItemCollapsibleState.None);
+        item.id = UNCOMMITTED_ID;
+        item.description = formatSummary(s.fileCount, s.insertions, s.deletions);
+        item.iconPath = new ThemeIcon('source-control');
+        item.contextValue = 'uncommitted';
+        item.checkboxState = this.isChecked(UNCOMMITTED_ID) ? TreeItemCheckboxState.Checked : TreeItemCheckboxState.Unchecked;
+        item.tooltip = 'Uncommitted changes in the working tree (compared to HEAD)';
+        return item;
+    }
+
+    async getChildren(element?: CommitListElement): Promise<CommitListElement[]> {
+        if (element) {
+            return []; // flat list
+        }
+        if (!this.host.getComparison()) {
+            return [];
+        }
+        const items: CommitListElement[] = [new UncommittedElement(this.uncommitted)];
+        for (const c of this.commits) {
+            items.push(new CommitElement(c));
+        }
+        return items;
+    }
+
+    dispose(): void {
+        this.disposables.forEach(d => d.dispose());
+    }
+}
+
+function escapeMarkdown(text: string): string {
+    return text.replace(/[\\`*_{}\[\]()#+\-.!]/g, '\\$&');
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,4 +1,4 @@
-import { ExtensionContext, window, Disposable, commands, extensions } from 'vscode';
+import { ExtensionContext, window, Disposable, commands, extensions, workspace } from 'vscode';
 
 import { NAMESPACE } from './constants'
 import { GitTreeCompareProvider } from './treeProvider';
@@ -167,15 +167,33 @@ export function activate(context: ExtensionContext) {
 
         provider.init(treeView);
 
-        commitsProvider = new CommitsTreeProvider(provider, outputChannel);
-        const commitsTreeView = window.createTreeView(
-            NAMESPACE + 'Commits',
-            {
-                treeDataProvider: commitsProvider,
+        // The "Commits" panel is optional and disabled by default; create/dispose it
+        // according to the gitTreeCompare.showCommitsPanel setting.
+        let commitsDisposables: Disposable[] = [];
+        const updateCommitsPanel = () => {
+            const enabled = workspace.getConfiguration(NAMESPACE).get<boolean>('showCommitsPanel', false);
+            if (enabled && !commitsProvider) {
+                commitsProvider = new CommitsTreeProvider(provider!, outputChannel);
+                const commitsTreeView = window.createTreeView(
+                    NAMESPACE + 'Commits',
+                    {
+                        treeDataProvider: commitsProvider,
+                    }
+                );
+                commitsDisposables.push(commitsTreeView, commitsProvider);
+                commitsProvider.init(commitsTreeView);
+            } else if (!enabled && commitsProvider) {
+                Disposable.from(...commitsDisposables).dispose();
+                commitsDisposables = [];
+                commitsProvider = null;
             }
-        );
-        disposables.push(commitsTreeView);
-        disposables.push(commitsProvider);
-        commitsProvider.init(commitsTreeView);
+        };
+        disposables.push(new Disposable(() => Disposable.from(...commitsDisposables).dispose()));
+        disposables.push(workspace.onDidChangeConfiguration(e => {
+            if (e.affectsConfiguration(NAMESPACE + '.showCommitsPanel')) {
+                updateCommitsPanel();
+            }
+        }));
+        updateCommitsPanel();
     });
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,6 +2,7 @@ import { ExtensionContext, window, Disposable, commands, extensions } from 'vsco
 
 import { NAMESPACE } from './constants'
 import { GitTreeCompareProvider } from './treeProvider';
+import { CommitsTreeProvider } from './commitsProvider';
 import { createGit } from './gitHelper';
 import { toDisposable } from './git/util';
 import { GitExtension } from './typings/git';
@@ -17,6 +18,7 @@ export function activate(context: ExtensionContext) {
     const gitApi = gitExt.getAPI(1);
 
     let provider: GitTreeCompareProvider | null = null;
+    let commitsProvider: CommitsTreeProvider | null = null;
 
     let runAfterInit = (fn: () => any) => {
         if (provider == null) {
@@ -132,6 +134,17 @@ export function activate(context: ExtensionContext) {
         runAfterInit(() => provider!.openChangesWithDifftool(node));
     });
 
+    commands.registerCommand(NAMESPACE + '.commits.selectAll', () => {
+        commitsProvider?.selectAll();
+    });
+    commands.registerCommand(NAMESPACE + '.commits.deselectAll', () => {
+        commitsProvider?.deselectAll();
+    });
+    commands.registerCommand(NAMESPACE + '.commits.refresh', () => {
+        // Refresh the whole comparison; the commits list updates via onDidChangeComparison.
+        runAfterInit(() => provider!.manualRefresh());
+    });
+
     createGit(gitApi, outputChannel).then(async git => {
         const onOutput = (str: string) => outputChannel.append(str);
         git.onOutput.addListener('log', onOutput);
@@ -153,5 +166,16 @@ export function activate(context: ExtensionContext) {
         );
 
         provider.init(treeView);
+
+        commitsProvider = new CommitsTreeProvider(provider, outputChannel);
+        const commitsTreeView = window.createTreeView(
+            NAMESPACE + 'Commits',
+            {
+                treeDataProvider: commitsProvider,
+            }
+        );
+        disposables.push(commitsTreeView);
+        disposables.push(commitsProvider);
+        commitsProvider.init(commitsTreeView);
     });
 }

--- a/src/gitHelper.ts
+++ b/src/gitHelper.ts
@@ -2,7 +2,7 @@ import * as path from 'path';
 import { promises as fs } from 'fs';
 
 import { workspace, OutputChannel, WorkspaceFolder } from 'vscode';
-import { Git, Repository } from './git/git';
+import { Git, Repository, IExecutionResult } from './git/git';
 import { Ref, Branch } from './git/api/git';
 import { normalizePath } from './fsUtils';
 import { API as GitAPI } from './typings/git';
@@ -114,6 +114,32 @@ export interface IDiffStats {
     insertions: number | undefined;
     deletions: number | undefined;
     isBinary: boolean;
+}
+
+/** The well-known SHA-1 of the empty git tree, usable as a diff base for root commits. */
+export const EMPTY_TREE_ID = '4b825dc642cb6eb9a060e54bf8d69288fbee4904';
+
+export interface ICommitInfo {
+    /** Full commit hash. */
+    hash: string;
+    /** Abbreviated commit hash. */
+    shortHash: string;
+    /** First line of the commit message. */
+    subject: string;
+    authorName: string;
+    authorDate: Date | undefined;
+    /** Parent commit hashes (first entry is the first parent). */
+    parents: string[];
+    /** Number of files changed in this commit. */
+    fileCount: number;
+    insertions: number;
+    deletions: number;
+}
+
+export interface IUncommittedSummary {
+    fileCount: number;
+    insertions: number;
+    deletions: number;
 }
 
 export interface IDiffStatus {
@@ -321,4 +347,132 @@ export async function hasUncommittedChanges(repo: Repository, path: string, igno
 
 export async function rmFile(repo: Repository, absPath: string): Promise<void> {
     await repo.exec(['rm', '-f', absPath]);
+}
+
+/**
+ * Diffs two tree-ish objects (commits/trees) against each other.
+ * Unlike {@link diffIndex}, this does not involve the working tree or untracked files.
+ * `diff-tree` is a plumbing command that always emits full object IDs, which the raw
+ * output parser relies on.
+ */
+export async function diffTrees(repo: Repository, leftRef: string, rightRef: string,
+        findRenames: boolean, renameThreshold: number, showDiffStats: boolean = false): Promise<IDiffStatus[]> {
+    const repoRoot = normalizePath(repo.root);
+    const renamesFlag = findRenames ? `--find-renames=${renameThreshold}%` : '--no-renames';
+
+    const rawResult = await repo.exec(['diff-tree', '-r', '-z', renamesFlag, leftRef, rightRef, '--']);
+    const statuses = parseDiffIndexOutput(repoRoot, rawResult.stdout);
+
+    if (showDiffStats) {
+        const numstatResult = await repo.exec(['diff', '--numstat', renamesFlag, leftRef, rightRef, '--']);
+        const numstatMap = parseDiffNumstat(repoRoot, numstatResult.stdout);
+        for (const entry of statuses) {
+            const fileStats = numstatMap.get(entry.dstAbsPath) || numstatMap.get(entry.srcAbsPath);
+            if (fileStats) {
+                entry.stats = fileStats;
+            }
+        }
+    }
+
+    statuses.sort((s1, s2) => s1.dstAbsPath.localeCompare(s2.dstAbsPath));
+    return statuses;
+}
+
+const LOG_RECORD_SEP = '\x1e';
+const LOG_FIELD_SEP = '\x1f';
+
+/**
+ * Returns the commits reachable from `headRef` but not from `baseRef` (i.e. `baseRef..headRef`),
+ * newest first, each annotated with aggregate diff stats (files/insertions/deletions).
+ * Merge commits are reported with zero stats since `--numstat` suppresses combined diffs.
+ */
+export async function getBranchCommits(repo: Repository, baseRef: string, headRef: string): Promise<ICommitInfo[]> {
+    const format = LOG_RECORD_SEP + ['%H', '%h', '%an', '%aI', '%P', '%s'].join(LOG_FIELD_SEP);
+    let result: IExecutionResult<string>;
+    try {
+        result = await repo.exec(['log', `${baseRef}..${headRef}`, '--numstat', `--format=${format}`]);
+    } catch (e) {
+        // e.g. unborn HEAD or invalid range
+        return [];
+    }
+
+    const commits: ICommitInfo[] = [];
+    let current: ICommitInfo | undefined;
+    for (const line of result.stdout.split('\n')) {
+        if (line.length === 0) {
+            continue;
+        }
+        if (line[0] === LOG_RECORD_SEP) {
+            const [hash, shortHash, authorName, authorISO, parents, subject] = line.slice(1).split(LOG_FIELD_SEP);
+            current = {
+                hash: hash || '',
+                shortHash: shortHash || '',
+                authorName: authorName || '',
+                authorDate: authorISO ? new Date(authorISO) : undefined,
+                parents: parents ? parents.split(' ').filter(p => p.length > 0) : [],
+                subject: subject || '',
+                fileCount: 0,
+                insertions: 0,
+                deletions: 0,
+            };
+            commits.push(current);
+        } else if (current) {
+            // numstat line: <insertions>\t<deletions>\t<path>
+            const tab1 = line.indexOf('\t');
+            if (tab1 === -1) {
+                continue;
+            }
+            const tab2 = line.indexOf('\t', tab1 + 1);
+            if (tab2 === -1) {
+                continue;
+            }
+            const insStr = line.substring(0, tab1);
+            const delStr = line.substring(tab1 + 1, tab2);
+            current.fileCount++;
+            if (insStr !== '-') {
+                current.insertions += parseInt(insStr, 10) || 0;
+            }
+            if (delStr !== '-') {
+                current.deletions += parseInt(delStr, 10) || 0;
+            }
+        }
+    }
+    return commits;
+}
+
+/**
+ * Computes an aggregate summary of uncommitted changes (working tree vs HEAD), including
+ * untracked files in the file count (unless omitted). Insertion/deletion counts cover
+ * tracked changes only.
+ */
+export async function getUncommittedSummary(repo: Repository, omitUntrackedFiles: boolean = false): Promise<IUncommittedSummary> {
+    const repoRoot = normalizePath(repo.root);
+    let fileCount = 0;
+    let insertions = 0;
+    let deletions = 0;
+
+    try {
+        const res = await repo.exec(['diff', '--numstat', 'HEAD', '--']);
+        const map = parseDiffNumstat(repoRoot, res.stdout);
+        for (const [, stats] of map) {
+            fileCount++;
+            if (!stats.isBinary) {
+                insertions += stats.insertions || 0;
+                deletions += stats.deletions || 0;
+            }
+        }
+    } catch (e) {
+        // HEAD may be unborn (no commits yet); ignore
+    }
+
+    if (!omitUntrackedFiles) {
+        try {
+            const res = await repo.exec(['ls-files', '-z', '--others', '--exclude-standard']);
+            fileCount += res.stdout.split('\0').filter(s => s.length > 0).length;
+        } catch (e) {
+            // ignore
+        }
+    }
+
+    return { fileCount, insertions, deletions };
 }

--- a/src/treeProvider.ts
+++ b/src/treeProvider.ts
@@ -123,6 +123,13 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
     private _onDidChangeComparison = new EventEmitter<void>();
     readonly onDidChangeComparison: Event<void> = this._onDidChangeComparison.event;
 
+    // Fired when a relevant change is detected in the repository working tree or refs,
+    // before the (main-tree-visibility-gated) diff recompute. Lets dependents such as the
+    // commits list refresh on their own schedule/visibility instead of piggybacking on the
+    // main tree's update.
+    private _onDidChangeRepository = new EventEmitter<void>();
+    readonly onDidChangeRepository: Event<void> = this._onDidChangeRepository.event;
+
     private fireTreeDataChange() {
         this.parentMap.clear();
         this.elementMap.clear();
@@ -872,6 +879,22 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
         };
     }
 
+    // Updates the cached comparison refs from git (merge base / HEAD) without recomputing
+    // the full file diff. Cheap enough to run on the commits list's own refresh schedule,
+    // so it stays current even while the main tree is hidden and its diff recompute is paused.
+    async refreshComparison(): Promise<void> {
+        if (!this.repository) {
+            return;
+        }
+        try {
+            if (await this.isHeadChanged()) {
+                await this.updateRefs(this.baseRef);
+            }
+        } catch (e: any) {
+            this.log('Refreshing the comparison for the commits list failed', e);
+        }
+    }
+
     async getBranchCommits(): Promise<ICommitInfo[]> {
         if (!this.repository) {
             return [];
@@ -1026,6 +1049,9 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
             this.log(`Ignoring change outside of repository: ${uri.fsPath}`)
             return
         }
+        // Notify dependents (e.g. the commits list) about the relevant change before the
+        // visibility pause below, so they can refresh even while the main tree is hidden.
+        this._onDidChangeRepository.fire();
         if (!window.state.focused || !this.treeView.visible) {
             if (this.isPaused) {
                 return;

--- a/src/treeProvider.ts
+++ b/src/treeProvider.ts
@@ -3,16 +3,19 @@ import * as path from 'path'
 import * as fs from 'fs'
 
 import { TreeDataProvider, TreeItem, TreeItemCollapsibleState,
-         Uri, Disposable, EventEmitter, TextDocumentShowOptions,
+         Uri, Disposable, EventEmitter, Event, TextDocumentShowOptions,
          QuickPickItem, ProgressLocation, Memento, OutputChannel,
-         workspace, commands, window, env, WorkspaceFoldersChangeEvent, TreeView, ThemeIcon, TreeItemCheckboxState, TreeCheckboxChangeEvent, authentication, TextEditor } from 'vscode'
+         workspace, commands, window, env, WorkspaceFoldersChangeEvent, TreeView, ThemeIcon, TreeItemCheckboxState, TreeCheckboxChangeEvent, authentication, TextEditor, TabInputTextDiff, Range, TextEditorRevealType } from 'vscode'
 import { NAMESPACE } from './constants'
 import { Repository, Git } from './git/git'
 import { Ref, RefType } from './git/api/git'
 import { anyEvent, filterEvent, eventToPromise } from './git/util'
 import { getDefaultBranch, getHeadModificationDate, getBranchCommit,
-         diffIndex, IDiffStatus, IDiffStats, StatusCode, getAbsGitDir,
-         getWorkspaceFolders, getGitRepositoryFolders, hasUncommittedChanges, rmFile } from './gitHelper'
+         diffIndex, diffTrees, IDiffStatus, IDiffStats, StatusCode, getAbsGitDir,
+         getWorkspaceFolders, getGitRepositoryFolders, hasUncommittedChanges, rmFile,
+         getBranchCommits as gitGetBranchCommits, getUncommittedSummary as gitGetUncommittedSummary,
+         ICommitInfo, IUncommittedSummary } from './gitHelper'
+import { CommitFilterSpec, ComparisonInfo, ComparisonHost, commitFilterSpecEquals } from './commitsProvider'
 import { tryDeepenForMergeBase } from './deepenHelper'
 import { debounce, throttle } from './git/decorators'
 import { normalizePath } from './fsUtils';
@@ -109,11 +112,16 @@ class ChangeRepositoryItem implements QuickPickItem {
 
 type FolderAbsPath = string;
 
-export class GitTreeCompareProvider implements TreeDataProvider<Element>, Disposable {
+export class GitTreeCompareProvider implements TreeDataProvider<Element>, Disposable, ComparisonHost {
 
     // Events
     private _onDidChangeTreeData = new EventEmitter<Element | void>();
     readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
+
+    // Fired whenever the active comparison (repository, base/merge base or HEAD) changes,
+    // so the commits list can refresh itself.
+    private _onDidChangeComparison = new EventEmitter<void>();
+    readonly onDidChangeComparison: Event<void> = this._onDidChangeComparison.event;
 
     private fireTreeDataChange() {
         this.parentMap.clear();
@@ -148,6 +156,10 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
     private viewAsList = false;
     private hideCheckedFiles = false;
     private searchFilter: string | undefined;
+
+    // Restricts the diff to a subset of commits selected in the commits list.
+    // Defaults to the full comparison (working tree vs base).
+    private commitFilter: CommitFilterSpec = { kind: 'all' };
 
     // Static state of repository
     private workspaceFolder: string;
@@ -244,6 +256,8 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
         this.repository = repository;
         this.absGitDir = absGitDir;
         this.repoRoot = repoRoot;
+        // Reset any commit selection from a previous repository.
+        this.commitFilter = { kind: 'all' };
 
         // Sort descending by folder depth
         workspaceFolders.sort((a, b) => {
@@ -640,15 +654,45 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
             if (!this.fullDiff && this.mergeBase !== mergeBase) {
                 this.log(`Merge base updated: ${this.mergeBase} -> ${mergeBase}`);
             }
+            // If the comparison identity changed (different merge base or HEAD commit),
+            // any previous commit selection no longer applies; reset to the full comparison.
+            const comparisonChanged = this.mergeBase !== mergeBase || this.headCommit !== headCommit;
+
             this.headLastChecked = headLastChecked;
             this.headName = headName;
             this.headCommit = headCommit;
             this.baseRef = baseRef;
             this.mergeBase = mergeBase;
             this.updateStoredBaseRef(baseRef);
+
+            if (comparisonChanged) {
+                this.commitFilter = { kind: 'all' };
+            }
         } catch (e) {
             throw e;
         }
+    }
+
+    // Computes the set of changed files for the active commit filter.
+    private async computeDiff(): Promise<IDiffStatus[]> {
+        const filter = this.commitFilter;
+        if (filter.kind === 'empty') {
+            return [];
+        }
+        if (filter.kind === 'range') {
+            const rightRef = filter.rightRef ?? null;
+            if (rightRef === null) {
+                // The right side is the working tree: reuse diff-index against the left ref
+                // (this also brings in untracked files when comparing against HEAD).
+                return diffIndex(this.repository!, filter.leftRef!, this.refreshIndex, this.findRenames,
+                    this.renameThreshold, this.omitUntrackedFiles, this.omitUnstagedChanges, this.showDiffStats);
+            }
+            return diffTrees(this.repository!, filter.leftRef!, rightRef, this.findRenames,
+                this.renameThreshold, this.showDiffStats);
+        }
+        // 'all': the full comparison, working tree vs base.
+        return diffIndex(this.repository!, this.mergeBase, this.refreshIndex, this.findRenames,
+            this.renameThreshold, this.omitUntrackedFiles, this.omitUnstagedChanges, this.showDiffStats);
     }
 
     @throttle
@@ -660,7 +704,7 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
         const filesInsideTreeRoot = new Map<FolderAbsPath, IDiffStatus[]>();
         const filesOutsideTreeRoot = new Map<FolderAbsPath, IDiffStatus[]>();
 
-        const diff = await diffIndex(this.repository!, this.mergeBase, this.refreshIndex, this.findRenames, this.renameThreshold, this.omitUntrackedFiles, this.omitUnstagedChanges, this.showDiffStats);
+        const diff = await this.computeDiff();
         const untrackedCount = diff.reduce((prev, cur, _) => prev + (cur.status === 'U' ? 1 : 0), 0);
         this.log(`${diff.length} diff entries (${untrackedCount} untracked)`);
 
@@ -673,6 +717,7 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
             if (fireChangeEvents) {
                 this.fireTreeDataChange();
             }
+            this._onDidChangeComparison.fire();
             return;
         }
 
@@ -808,6 +853,144 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
             this.log('Refreshing tree')
             this.fireTreeDataChange();
         }
+
+        // Let the commits list know the comparison may have changed (new commits, updated
+        // uncommitted summary, etc.).
+        this._onDidChangeComparison.fire();
+    }
+
+    // --- ComparisonHost implementation (consumed by the commits list) ---
+
+    getComparison(): ComparisonInfo | undefined {
+        if (!this.repository || !this.baseRef) {
+            return undefined;
+        }
+        return {
+            repoRoot: this.repoRoot,
+            mergeBase: this.mergeBase,
+            headCommit: this.headCommit,
+        };
+    }
+
+    async getBranchCommits(): Promise<ICommitInfo[]> {
+        if (!this.repository) {
+            return [];
+        }
+        return gitGetBranchCommits(this.repository, this.mergeBase, this.headCommit);
+    }
+
+    async getUncommittedSummary(): Promise<IUncommittedSummary> {
+        if (!this.repository) {
+            return { fileCount: 0, insertions: 0, deletions: 0 };
+        }
+        return gitGetUncommittedSummary(this.repository, this.omitUntrackedFiles);
+    }
+
+    async setCommitFilter(spec: CommitFilterSpec): Promise<void> {
+        if (commitFilterSpecEquals(this.commitFilter, spec)) {
+            return;
+        }
+        this.commitFilter = spec;
+        try {
+            await this.updateDiff(false);
+        } catch (e: any) {
+            this.log('Updating the diff for the commit selection failed', e);
+            window.showErrorMessage(`Updating the diff failed: ${e.message}`);
+        }
+        this.fireTreeDataChange();
+        // Keep a currently visible diff in sync with the new selection.
+        await this.refreshActiveDiff();
+    }
+
+    // If the active editor is a diff we opened for a file that is still part of the
+    // current selection, re-open it so it reflects the newly selected commit(s).
+    private async refreshActiveDiff(): Promise<void> {
+        const tab = window.tabGroups.activeTabGroup?.activeTab;
+        if (!tab || !(tab.input instanceof TabInputTextDiff)) {
+            return;
+        }
+        // Only update a preview tab: re-opening replaces it in place. Pinned/non-preview
+        // diffs are left as the user explicitly kept them (and can't be replaced cleanly).
+        if (!tab.isPreview) {
+            return;
+        }
+        const input = tab.input;
+        // Only act on diffs produced by this extension (the left side is a git: URI).
+        if (input.original.scheme !== 'git') {
+            return;
+        }
+        const dstAbsPath = this.uriToAbsPath(input.modified);
+        if (!dstAbsPath) {
+            return;
+        }
+        const diffStatus = this.getDiffStatusForPath(dstAbsPath);
+        if (!diffStatus) {
+            // File is not part of the current selection; leave the existing diff untouched.
+            return;
+        }
+
+        // Remember the current scroll position (top visible line) so we can restore it
+        // after re-opening with the new commit's content.
+        const oldUris = new Set([input.original.toString(), input.modified.toString()]);
+        const prevEditor = window.visibleTextEditors.find(e => oldUris.has(e.document.uri.toString()));
+        const anchorLine = prevEditor?.visibleRanges[0]?.start.line;
+
+        const showOptions: TextDocumentShowOptions = { viewColumn: tab.group.viewColumn, preserveFocus: true };
+        if (anchorLine !== undefined) {
+            // Positions the re-opened diff near the previous location during the open itself.
+            showOptions.selection = new Range(anchorLine, 0, anchorLine, 0);
+        }
+
+        await this.doOpenChanges(diffStatus.srcAbsPath, diffStatus.dstAbsPath, diffStatus.status, true, showOptions);
+
+        if (anchorLine === undefined) {
+            return;
+        }
+
+        // Refine: pin the previous top line to the top of the viewport.
+        const { leftRef, rightRef } = this.getDiffEndpoints();
+        const newUris = new Set<string>([
+            (rightRef === null ? Uri.file(diffStatus.dstAbsPath) : this.gitApi.toGitUri(Uri.file(diffStatus.dstAbsPath), rightRef)).toString(),
+            this.gitApi.toGitUri(Uri.file(diffStatus.srcAbsPath), leftRef).toString(),
+        ]);
+        const newEditor = window.visibleTextEditors.find(e => newUris.has(e.document.uri.toString()));
+        if (newEditor) {
+            const line = Math.min(anchorLine, Math.max(0, newEditor.document.lineCount - 1));
+            newEditor.revealRange(new Range(line, 0, line, 0), TextEditorRevealType.AtTop);
+        }
+    }
+
+    private uriToAbsPath(uri: Uri): string | undefined {
+        if (uri.scheme === 'file') {
+            return uri.fsPath;
+        }
+        if (uri.scheme === 'git') {
+            try {
+                const params = JSON.parse(uri.query);
+                if (params && typeof params.path === 'string') {
+                    return params.path;
+                }
+            } catch {
+                // not a git URI we can interpret
+            }
+        }
+        return undefined;
+    }
+
+    private getDiffStatusForPath(dstAbsPath: string): IDiffStatus | undefined {
+        const folder = path.dirname(dstAbsPath);
+        const isInsideTreeRoot = folder === this.treeRoot || folder.startsWith(this.treeRoot + path.sep);
+        const files = isInsideTreeRoot ? this.filesInsideTreeRoot : this.filesOutsideTreeRoot;
+        return files.get(folder)?.find(file => file.dstAbsPath === dstAbsPath);
+    }
+
+    // Resolves the two endpoints used when opening a file's changes, based on the
+    // active commit filter. `rightRef === null` means the working tree.
+    private getDiffEndpoints(): { leftRef: string, rightRef: string | null } {
+        if (this.commitFilter.kind === 'range') {
+            return { leftRef: this.commitFilter.leftRef!, rightRef: this.commitFilter.rightRef ?? null };
+        }
+        return { leftRef: this.mergeBase, rightRef: null };
     }
 
     private async isHeadChanged() {
@@ -1167,23 +1350,24 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
         await this.doOpenChanges(diffStatus.srcAbsPath, diffStatus.dstAbsPath, diffStatus.status);
     }
 
-    async doOpenChanges(srcAbsPath: string, dstAbsPath: string, status: StatusCode, preview=true) {
-        const right = Uri.file(dstAbsPath);
-        const left = this.gitApi.toGitUri(Uri.file(srcAbsPath), this.mergeBase);
+    async doOpenChanges(srcAbsPath: string, dstAbsPath: string, status: StatusCode, preview=true, showOptions: TextDocumentShowOptions = {}) {
+        const { leftRef, rightRef } = this.getDiffEndpoints();
+        const right = rightRef === null ? Uri.file(dstAbsPath) : this.gitApi.toGitUri(Uri.file(dstAbsPath), rightRef);
+        const left = this.gitApi.toGitUri(Uri.file(srcAbsPath), leftRef);
+
+        const options: TextDocumentShowOptions = { preview, ...showOptions };
 
         if (status === 'U' || status === 'A') {
-            return commands.executeCommand('vscode.open', right);
+            return commands.executeCommand('vscode.open', right, options);
         }
         if (status === 'D') {
-            return commands.executeCommand('vscode.open', left);
+            return commands.executeCommand('vscode.open', left, options);
         }
 
-        const options: TextDocumentShowOptions = {
-            preview: preview
-        };
         const filename = path.basename(dstAbsPath);
+        const rightLabel = rightRef === null ? 'Working Tree' : rightRef.substr(0, 7);
         return await commands.executeCommand('vscode.diff',
-            left, right, filename + " (Working Tree)", options);
+            left, right, `${filename} (${rightLabel})`, options);
     }
 
     openAllChanges(entry: RefElement | RepoRootElement | FolderElement | undefined) {
@@ -1203,8 +1387,9 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
     }
 
     async doOpenFile(dstAbsPath: string, status: StatusCode, preview=false) {
-        const right = Uri.file(dstAbsPath);
-        const left = this.gitApi.toGitUri(right, this.mergeBase);
+        const { leftRef, rightRef } = this.getDiffEndpoints();
+        const right = rightRef === null ? Uri.file(dstAbsPath) : this.gitApi.toGitUri(Uri.file(dstAbsPath), rightRef);
+        const left = this.gitApi.toGitUri(Uri.file(dstAbsPath), leftRef);
         const uri = status === 'D' ? left : right;
         const options: TextDocumentShowOptions = {
             preview: preview
@@ -1213,6 +1398,10 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
     }
 
     async discardChanges(entries: (FileElement | FolderElement)[]) {
+        if (this.commitFilter.kind !== 'all') {
+            window.showInformationMessage('Discarding changes is only available in the full comparison. Select all commits first.');
+            return;
+        }
         let statuses: IDiffStatus[] = [];
         for (const entry of entries) {
             if (entry instanceof FolderElement) {
@@ -1228,6 +1417,10 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
     }
 
     async discardAllChanges() {
+        if (this.commitFilter.kind !== 'all') {
+            window.showInformationMessage('Discarding changes is only available in the full comparison. Select all commits first.');
+            return;
+        }
         const statuses = [...this.iterFiles()];
         await this.doDiscardChanges(statuses);
     }
@@ -1775,9 +1968,14 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
         // Calculate relative path from repository root
         const dstRelPath = path.relative(this.repository.root, dstAbsPath);
 
-        // For modified files, use git difftool
-        // Use the mergeBase as the comparison base
-        const args = ['difftool', '--no-prompt', this.mergeBase, '--', dstRelPath];
+        // Use the active comparison endpoints (merge base + working tree by default,
+        // or the selected commit range).
+        const { leftRef, rightRef } = this.getDiffEndpoints();
+        const args = ['difftool', '--no-prompt', leftRef];
+        if (rightRef !== null) {
+            args.push(rightRef);
+        }
+        args.push('--', dstRelPath);
 
         try {
             // Execute git difftool - this will launch the external tool


### PR DESCRIPTION
Adds a "Commits" view below the file tree listing the commits between the base and HEAD, with an "Uncommitted Changes" entry on top. Each row has a checkbox and a files/+/- summary.

By default everything is checked and the tree shows the full comparison. Checking a subset narrows it:
- single commit -> that commit's own diff (commit^..commit)
- Uncommitted Changes -> working tree vs HEAD
- several commits -> combined diff of the selected range
- Select All / Deselect All in the title bar

Opening a file uses the current selection for the diff sides, and an open preview diff follows the selection while keeping its scroll position. Discard is restricted to the full comparison.

<img width="1103" height="788" alt="Image" src="https://github.com/user-attachments/assets/6a287960-d87f-4511-a13b-868091835560" />


https://github.com/user-attachments/assets/9fa2b9c6-141f-430e-8c9d-0d6a1a6f56f4

