### PR TITLE
Fix: auto-refresh Git Tree Compare when switching to a linked worktree

### DIFF
--- a/src/gitHelper.ts
+++ b/src/gitHelper.ts
@@ -40,6 +40,38 @@ export function getGitRepositoryFolders(git: GitAPI, selectedFirst=false): strin
     return rootPaths;
 }
 
+export interface IWorktreeInfo {
+        path: string;
+        head: string;
+        branch: string | undefined;
+}
+export async function listWorktrees(repo: Repository): Promise<IWorktreeInfo[]> {
+        const result = await repo.exec(['worktree', 'list', '--porcelain']);
+        const worktrees: IWorktreeInfo[] = [];
+        let currentPath: string | undefined;
+        let currentHead: string | undefined;
+        let currentBranch: string | undefined;
+
+        const flush = () => {
+                    if (currentPath && currentHead) {
+                                    worktrees.push({ path: normalizePath(currentPath), head: currentHead, branch: currentBranch });
+                    }
+                    currentPath = currentHead = currentBranch = undefined;
+        };
+
+        for (const line of result.stdout.split('\n')) {
+                    if (line.startsWith('worktree ')) {
+                                    flush();
+                                    currentPath = line.slice('worktree '.length);
+                    } else if (line.startsWith('HEAD ')) {
+                                    currentHead = line.slice('HEAD '.length);
+                    } else if (line.startsWith('branch refs/heads/')) {
+                                    currentBranch = line.slice('branch refs/heads/'.length);
+                    }
+        }
+        flush(); // flush the last entry
+        return worktrees;
+}
 export async function getAbsGitDir(repo: Repository): Promise<string> {
     // We don't use --absolute-git-dir here as that requires git >= 2.13.
     let res = await repo.exec(['rev-parse', '--git-dir']);

--- a/src/gitHelper.ts
+++ b/src/gitHelper.ts
@@ -41,37 +41,39 @@ export function getGitRepositoryFolders(git: GitAPI, selectedFirst=false): strin
 }
 
 export interface IWorktreeInfo {
-        path: string;
-        head: string;
-        branch: string | undefined;
+    path: string;
+    head: string;
+    branch: string | undefined;
 }
+
 export async function listWorktrees(repo: Repository): Promise<IWorktreeInfo[]> {
-        const result = await repo.exec(['worktree', 'list', '--porcelain']);
-        const worktrees: IWorktreeInfo[] = [];
-        let currentPath: string | undefined;
-        let currentHead: string | undefined;
-        let currentBranch: string | undefined;
+    const result = await repo.exec(['worktree', 'list', '--porcelain']);
+    const worktrees: IWorktreeInfo[] = [];
+    let currentPath: string | undefined;
+    let currentHead: string | undefined;
+    let currentBranch: string | undefined;
 
-        const flush = () => {
-                    if (currentPath && currentHead) {
-                                    worktrees.push({ path: normalizePath(currentPath), head: currentHead, branch: currentBranch });
-                    }
-                    currentPath = currentHead = currentBranch = undefined;
-        };
-
-        for (const line of result.stdout.split('\n')) {
-                    if (line.startsWith('worktree ')) {
-                                    flush();
-                                    currentPath = line.slice('worktree '.length);
-                    } else if (line.startsWith('HEAD ')) {
-                                    currentHead = line.slice('HEAD '.length);
-                    } else if (line.startsWith('branch refs/heads/')) {
-                                    currentBranch = line.slice('branch refs/heads/'.length);
-                    }
+    const flush = () => {
+        if (currentPath && currentHead) {
+            worktrees.push({ path: normalizePath(currentPath), head: currentHead, branch: currentBranch });
         }
-        flush(); // flush the last entry
-        return worktrees;
+        currentPath = currentHead = currentBranch = undefined;
+    };
+
+    for (const line of result.stdout.split('\n')) {
+        if (line.startsWith('worktree ')) {
+            flush();
+            currentPath = line.slice('worktree '.length);
+        } else if (line.startsWith('HEAD ')) {
+            currentHead = line.slice('HEAD '.length);
+        } else if (line.startsWith('branch refs/heads/')) {
+            currentBranch = line.slice('branch refs/heads/'.length);
+        }
+    }
+    flush(); // flush the last entry
+    return worktrees;
 }
+
 export async function getAbsGitDir(repo: Repository): Promise<string> {
     // We don't use --absolute-git-dir here as that requires git >= 2.13.
     let res = await repo.exec(['rev-parse', '--git-dir']);

--- a/src/treeProvider.ts
+++ b/src/treeProvider.ts
@@ -12,7 +12,7 @@ import { Ref, RefType } from './git/api/git'
 import { anyEvent, filterEvent, eventToPromise } from './git/util'
 import { getDefaultBranch, getHeadModificationDate, getBranchCommit,
          diffIndex, IDiffStatus, IDiffStats, StatusCode, getAbsGitDir,
-         getWorkspaceFolders, getGitRepositoryFolders, hasUncommittedChanges, rmFile } from './gitHelper'
+         getWorkspaceFolders, getGitRepositoryFolders, hasUncommittedChanges, rmFile , listWorktrees, IWorktreeInfo} from './gitHelper'h
 import { tryDeepenForMergeBase } from './deepenHelper'
 import { debounce, throttle } from './git/decorators'
 import { normalizePath } from './fsUtils';
@@ -238,7 +238,7 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
 
         const workspaceFolders = getWorkspaceFolders(repoRoot);
         if (workspaceFolders.length == 0) {
-            throw new Error(`Could not find any workspace folder for ${repositoryRoot}`);
+            const worktrees = await listWorktrees(repository);                const isLinkedWorktree = worktrees.some(wt => wt.path === repoRoot);
         }
 
         this.repository = repository;
@@ -324,9 +324,13 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
             return;
         }
         let repoRoot = repository.rootUri.fsPath;
-        if (!getGitRepositoryFolders(this.gitApi).includes(repoRoot)) {
-            return;
-        }
+const inWorkspace = getGitRepositoryFolders(this.gitApi).includes(repository.rootUri.fsPath);
+		        if (!inWorkspace) {
+					            const worktrees = this.repository ? await listWorktrees(this.repository) : [];
+					            if (!worktrees.some(wt => wt.path === repoRoot)) {
+									                return;
+								}
+				}
         repoRoot = normalizePath(repoRoot);
         if (repoRoot === this.workspaceFolder) {
             return;

--- a/src/treeProvider.ts
+++ b/src/treeProvider.ts
@@ -5,14 +5,14 @@ import * as fs from 'fs'
 import { TreeDataProvider, TreeItem, TreeItemCollapsibleState,
          Uri, Disposable, EventEmitter, TextDocumentShowOptions,
          QuickPickItem, ProgressLocation, Memento, OutputChannel,
-         workspace, commands, window, env, WorkspaceFoldersChangeEvent, TreeView, ThemeIcon, TreeItemCheckboxState, TreeCheckboxChangeEvent, authentication, TextEditor } from 'vscode'
+         workspace, commands, window, env, WorkspaceFoldersChangeEvent, TreeView, ThemeIcon, TreeItemCheckboxState, TreeCheckboxChangeEvent, authentication, TextEditor, RelativePattern } from 'vscode'
 import { NAMESPACE } from './constants'
 import { Repository, Git } from './git/git'
 import { Ref, RefType } from './git/api/git'
 import { anyEvent, filterEvent, eventToPromise } from './git/util'
 import { getDefaultBranch, getHeadModificationDate, getBranchCommit,
          diffIndex, IDiffStatus, IDiffStats, StatusCode, getAbsGitDir,
-         getWorkspaceFolders, getGitRepositoryFolders, hasUncommittedChanges, rmFile , listWorktrees, IWorktreeInfo} from './gitHelper'
+         getWorkspaceFolders, getGitRepositoryFolders, hasUncommittedChanges, rmFile, listWorktrees } from './gitHelper'
 import { tryDeepenForMergeBase } from './deepenHelper'
 import { debounce, throttle } from './git/decorators'
 import { normalizePath } from './fsUtils';
@@ -178,6 +178,7 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
 
     // Other
     private readonly disposables: Disposable[] = [];
+    private extraRepositoryWatcher: Disposable | undefined;
 
     constructor(private readonly git: Git, private readonly gitApi: GitAPI, private readonly outputChannel: OutputChannel, private readonly globalState: Memento,
                 private readonly asAbsolutePath: (relPath: string) => string) {
@@ -237,9 +238,14 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
         const repoRoot = normalizePath(repository.root);
 
         const workspaceFolders = getWorkspaceFolders(repoRoot);
-        if (workspaceFolders.length == 0) {
+        const outsideWorkspace = workspaceFolders.length == 0;
+        if (outsideWorkspace) {
             const worktrees = await listWorktrees(repository);
-			const isLinkedWorktree = worktrees.some(wt => wt.path === repoRoot);
+            const isLinkedWorktree = worktrees.some(wt => wt.path === repoRoot);
+            if (!isLinkedWorktree) {
+                throw new Error(`Could not find any workspace folder for ${repositoryRoot}`);
+            }
+            workspaceFolders.push({ uri: Uri.file(repoRoot), name: path.basename(repoRoot), index: 0 });
         }
 
         this.repository = repository;
@@ -257,6 +263,7 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
         this.workspaceFolder = normalizePath(workspaceFolders[0].uri.fsPath);
         this.updateTreeRootFolder();
         this.log('Using repository: ' + this.repoRoot);
+        this.updateExtraRepositoryWatcher(outsideWorkspace);
 
         this.updateTreeTitle();
     }
@@ -276,6 +283,7 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
 
     async unsetRepository() {
         this.repository = undefined;
+        this.updateExtraRepositoryWatcher(false);
         this.fireTreeDataChange();
         this.log('No repository selected');
 
@@ -324,20 +332,42 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
         if (!this.autoChangeRepository || !repository.ui.selected) {
             return;
         }
-        let repoRoot = repository.rootUri.fsPath;
-		const inWorkspace = getGitRepositoryFolders(this.gitApi).includes(repository.rootUri.fsPath);
-			if (!inWorkspace) {
-				const worktrees = this.repository ? await listWorktrees(this.repository) : [];
-				if (!worktrees.some(wt => wt.path === repoRoot)) {
-					return;
-				}
-			}
-        repoRoot = normalizePath(repoRoot);
-        if (repoRoot === this.workspaceFolder) {
+        const repoRoot = normalizePath(repository.rootUri.fsPath);
+        const inWorkspace = getGitRepositoryFolders(this.gitApi).map(normalizePath).includes(repoRoot);
+        if (!inWorkspace) {
+            const worktrees = this.repository ? await listWorktrees(this.repository) : [];
+            if (!worktrees.some(wt => wt.path === repoRoot)) {
+                return;
+            }
+        }
+        if (repoRoot === this.repoRoot) {
             return;
         }
         this.log(`SCM repository change detected - changing repository: ${repoRoot}`);
         await this.changeRepository(repoRoot);
+    }
+
+    private updateExtraRepositoryWatcher(enabled: boolean) {
+        this.extraRepositoryWatcher?.dispose();
+        this.extraRepositoryWatcher = undefined;
+
+        if (!enabled) {
+            return;
+        }
+
+        const watchers = [
+            workspace.createFileSystemWatcher(new RelativePattern(Uri.file(this.repoRoot), '**')),
+        ];
+        const normalizedGitDir = normalizePath(this.absGitDir);
+        if (normalizedGitDir !== this.repoRoot && !normalizedGitDir.startsWith(this.repoRoot + path.sep)) {
+            watchers.push(workspace.createFileSystemWatcher(new RelativePattern(Uri.file(this.absGitDir), '**')));
+        }
+
+        const subscriptions = watchers.map(watcher => {
+            const onWorkspaceChange = anyEvent(watcher.onDidChange, watcher.onDidCreate, watcher.onDidDelete);
+            return onWorkspaceChange(this.handleWorkspaceChange, this);
+        });
+        this.extraRepositoryWatcher = Disposable.from(...watchers, ...subscriptions);
     }
 
     private async handleWorkspaceFoldersChanged(e: WorkspaceFoldersChangeEvent) {
@@ -844,7 +874,8 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
         // ignore changes outside of repo root
         //  e.g. "c:\Users\..\AppData\Roaming\Code - Insiders\User\globalStorage"
         const normPath = normalizePath(uri.fsPath);
-        if (!normPath.startsWith(this.repoRoot + path.sep)) {
+        const normalizedGitDir = normalizePath(this.absGitDir);
+        if (!normPath.startsWith(this.repoRoot + path.sep) && !normPath.startsWith(normalizedGitDir + path.sep)) {
             this.log(`Ignoring change outside of repository: ${uri.fsPath}`)
             return
         }
@@ -1803,6 +1834,7 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
     }
 
     dispose(): void {
+        this.extraRepositoryWatcher?.dispose();
         this.disposables.forEach(d => d.dispose());
     }
 }

--- a/src/treeProvider.ts
+++ b/src/treeProvider.ts
@@ -12,7 +12,7 @@ import { Ref, RefType } from './git/api/git'
 import { anyEvent, filterEvent, eventToPromise } from './git/util'
 import { getDefaultBranch, getHeadModificationDate, getBranchCommit,
          diffIndex, IDiffStatus, IDiffStats, StatusCode, getAbsGitDir,
-         getWorkspaceFolders, getGitRepositoryFolders, hasUncommittedChanges, rmFile , listWorktrees, IWorktreeInfo} from './gitHelper'h
+         getWorkspaceFolders, getGitRepositoryFolders, hasUncommittedChanges, rmFile , listWorktrees, IWorktreeInfo} from './gitHelper'
 import { tryDeepenForMergeBase } from './deepenHelper'
 import { debounce, throttle } from './git/decorators'
 import { normalizePath } from './fsUtils';
@@ -238,7 +238,8 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
 
         const workspaceFolders = getWorkspaceFolders(repoRoot);
         if (workspaceFolders.length == 0) {
-            const worktrees = await listWorktrees(repository);                const isLinkedWorktree = worktrees.some(wt => wt.path === repoRoot);
+            const worktrees = await listWorktrees(repository);
+			const isLinkedWorktree = worktrees.some(wt => wt.path === repoRoot);
         }
 
         this.repository = repository;
@@ -324,13 +325,13 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
             return;
         }
         let repoRoot = repository.rootUri.fsPath;
-const inWorkspace = getGitRepositoryFolders(this.gitApi).includes(repository.rootUri.fsPath);
-		        if (!inWorkspace) {
-					            const worktrees = this.repository ? await listWorktrees(this.repository) : [];
-					            if (!worktrees.some(wt => wt.path === repoRoot)) {
-									                return;
-								}
+		const inWorkspace = getGitRepositoryFolders(this.gitApi).includes(repository.rootUri.fsPath);
+			if (!inWorkspace) {
+				const worktrees = this.repository ? await listWorktrees(this.repository) : [];
+				if (!worktrees.some(wt => wt.path === repoRoot)) {
+					return;
 				}
+			}
         repoRoot = normalizePath(repoRoot);
         if (repoRoot === this.workspaceFolder) {
             return;

--- a/src/treeProvider.ts
+++ b/src/treeProvider.ts
@@ -201,30 +201,10 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
             this.disposables.push(repository.ui.onDidChange(() => this.handleRepositoryUiChange(repository)));
         }
 
-        const isRelevantChange = (uri: Uri) => {
-            if (uri.scheme != 'file') {
-                return false;
-            }
-            // non-git change
-            if (!/\/\.git\//.test(uri.path) && !/\/\.git$/.test(uri.path)) {
-                return true;
-            }
-            // git ref change
-            if (/\/\.git\/refs\//.test(uri.path) && !/\/\.git\/refs\/remotes\/.+\/actions/.test(uri.path)) {
-                return true;
-            }
-            // git index change
-            if (/\/\.git\/index$/.test(uri.path)) {
-                return true;
-            }
-            this.log(`Ignoring irrelevant change: ${uri.fsPath}`);
-            return false;
-        }
-
         const fsWatcher = workspace.createFileSystemWatcher('**');
         this.disposables.push(fsWatcher);
         const onWorkspaceChange = anyEvent(fsWatcher.onDidChange, fsWatcher.onDidCreate, fsWatcher.onDidDelete);
-        const onRelevantWorkspaceChange = filterEvent(onWorkspaceChange, isRelevantChange);
+        const onRelevantWorkspaceChange = filterEvent(onWorkspaceChange, uri => this.isRelevantChange(uri));
         this.disposables.push(onRelevantWorkspaceChange(this.handleWorkspaceChange, this));
 
         this.disposables.push(treeView.onDidChangeCheckboxState(this.handleChangeCheckboxState, this));
@@ -347,6 +327,30 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
         await this.changeRepository(repoRoot);
     }
 
+    private isRelevantChange(uri: Uri): boolean {
+        if (uri.scheme != 'file') {
+            return false;
+        }
+        // non-git change
+        if (!/\/\.git\//.test(uri.path) && !/\/\.git$/.test(uri.path)) {
+            return true;
+        }
+        // git ref change (including linked worktrees)
+        if (/\/\.git\/(?:worktrees\/[^/]+\/)?refs\//.test(uri.path) && !/\/\.git\/refs\/remotes\/.+\/actions/.test(uri.path)) {
+            return true;
+        }
+        // git HEAD change, e.g. on branch switch (including linked worktrees)
+        if (/\/\.git\/(?:worktrees\/[^/]+\/)?HEAD$/.test(uri.path)) {
+            return true;
+        }
+        // git index change (including linked worktrees)
+        if (/\/\.git\/(?:worktrees\/[^/]+\/)?index$/.test(uri.path)) {
+            return true;
+        }
+        this.log(`Ignoring irrelevant change: ${uri.fsPath}`);
+        return false;
+    }
+
     private updateExtraRepositoryWatcher(enabled: boolean) {
         this.extraRepositoryWatcher?.dispose();
         this.extraRepositoryWatcher = undefined;
@@ -365,7 +369,8 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
 
         const subscriptions = watchers.map(watcher => {
             const onWorkspaceChange = anyEvent(watcher.onDidChange, watcher.onDidCreate, watcher.onDidDelete);
-            return onWorkspaceChange(this.handleWorkspaceChange, this);
+            const onRelevantWorkspaceChange = filterEvent(onWorkspaceChange, uri => this.isRelevantChange(uri));
+            return onRelevantWorkspaceChange(this.handleWorkspaceChange, this);
         });
         this.extraRepositoryWatcher = Disposable.from(...watchers, ...subscriptions);
     }


### PR DESCRIPTION
## Problem

When `gitTreeCompare.autoChangeRepository` is enabled and a linked worktree is selected in the SCM view, Git Tree Compare can switch to that repository but then stop updating automatically.

The failing case is a linked worktree outside the opened VS Code workspace. The existing `workspace.createFileSystemWatcher('**')` only watches opened workspace folders, so file/index/ref changes from the selected worktree are not reported to Git Tree Compare.

## Fix

Keep the existing workspace watcher unchanged, and add a small fallback for linked worktrees outside the workspace:

- allow `setRepository()` to accept a repository path confirmed by `git worktree list --porcelain`, using that path as the tree workspace root;
- compare SCM repository selection against `this.repoRoot` so selecting the current repo does not trigger redundant switches;
- create an extra watcher only for out-of-workspace linked worktrees, including the linked worktree git directory so commits/index/ref updates can refresh the tree;
- dispose that extra watcher when switching away or disposing the provider.

## Notes

This keeps the change scoped to `treeProvider.ts`. The existing SCM selection flow still uses `repository.ui.onDidChange`; the added piece is watcher coverage for selected linked worktrees that are outside the opened workspace.

A demo GIF is attached in the PR discussion.