### PR TITLE
Show status badges with file theme icons

### DIFF
--- a/package.json
+++ b/package.json
@@ -579,9 +579,9 @@
                     ],
                     "enumDescriptions": [
                         "Use the extension's git status icons for files.",
-                        "Use VS Code file theme icons and color file labels by git status."
+                        "Use VS Code file theme icons and show git status with file decorations."
                     ],
-                    "description": "Which icon style to use for files in the compare tree.",
+                    "description": "Which icon style to use for files in the compare tree. File theme icons show Git status through file decorations.",
                     "default": "status"
                 },
                 "gitTreeCompare.collapsed": {

--- a/src/treeProvider.ts
+++ b/src/treeProvider.ts
@@ -1895,7 +1895,7 @@ class GitTreeCompareFileDecorationProvider implements FileDecorationProvider {
         if (uri.scheme !== TREE_RESOURCE_SCHEME || !isStatusCode(uri.query)) {
             return undefined;
         }
-        return new FileDecoration(undefined, getStatusText(uri.query), getStatusColor(uri.query));
+        return new FileDecoration(getStatusBadge(uri.query), getStatusText(uri.query), getStatusColor(uri.query));
     }
 }
 
@@ -2020,6 +2020,10 @@ function getStatusText(status: StatusCode) {
         case 'T': return 'Type changed';
         case 'R': return 'Renamed';
     }
+}
+
+function getStatusBadge(status: StatusCode) {
+    return status === 'C' ? '!' : status;
 }
 
 function getStatusColor(status: StatusCode): ThemeColor {


### PR DESCRIPTION
## Summary

- show Git status badges in `fileTheme` mode
- use the same status letters as VS Code's built-in Git extension, including `!` for conflicts
- keep the existing `status` icon mode and default unchanged

Fixes #150

## Testing

- `npm run compile`
