### PR TITLE
Use get remotes

### DIFF
--- a/src/treeProvider.ts
+++ b/src/treeProvider.ts
@@ -1573,7 +1573,8 @@ export class GitTreeCompareProvider implements TreeDataProvider<Element>, Dispos
                 const baseCloneUrl = pr.base.repo.clone_url;
                 const baseSshUrl = pr.base.repo.ssh_url;
                 const normalizeRemoteUrl = (u: string) => u.toLowerCase().replace(/\.git$/, '').replace(/^git@github\.com:/, 'https://github.com/');
-                const baseRemoteName = repository.remotes.find(r => {
+                const remotes = await repository.getRemotes();
+                const baseRemoteName = remotes.find(r => {
                     const url = normalizeRemoteUrl(r.fetchUrl || r.pushUrl || '');
                     return url === normalizeRemoteUrl(baseCloneUrl) || url === normalizeRemoteUrl(baseSshUrl);
                 })?.name ?? 'origin';


### PR DESCRIPTION
Should fix `TS2339: Property 'remotes' does not exist on type 'Repository'.` from here: https://github.com/letmaik/vscode-git-tree-compare/actions/runs/33132046040/job/98723561968#step:5:41